### PR TITLE
Update deprecated `engines` and `exclude_paths`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,9 +4,8 @@ plugins:
     enabled: true
   fixme:
     enabled: true
-engines:
   duplication:
-    exclude_paths:
+    exclude_patterns:
     - "**/*.test.js"
     - "**/*.e2e.js"
 exclude_patterns:


### PR DESCRIPTION
## Description
- Put all plugins under `plugins` node (remove deprecated and redundant `engines` node)
- Rename `exclude_paths` to `exclude_patterns` (`exclude_paths` is deprecated)

## Motivation and Context
- The `engines` and `plugins` node provide the same functionality
- `engines` is now deprecated`
- Using `engines` and `plugins` together will break the analysis
- `exclude_paths` is deprecated

## How Has This Been Tested?
- I forked the repo and added it to Code Climate
- Made these changes on my fork
- Got a successful analysis


## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
