### PR TITLE
Support ES2015 in colorers, meshes, modes 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["env"],
-  "plugins": ["syntax-dynamic-import"],
+  "plugins": ["syntax-dynamic-import", "transform-class-properties"],
   "env": {
     "coverage": {
       "plugins": ["istanbul"]

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.6",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,7 @@ export default {
       babelrc: false,
       runtimeHelpers: true,
       presets: [['env', {modules: false}]],
-      plugins: ['external-helpers'],
+      plugins: ['external-helpers', 'transform-class-properties'],
       exclude: [
         './node_modules/**',
         './vendor/js/**',

--- a/src/gfx/colorers/ChainColorer.js
+++ b/src/gfx/colorers/ChainColorer.js
@@ -1,27 +1,24 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
-function ChainColorer(opts) {
-  Colorer.call(this, opts);
+class ChainColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, complex) {
+    return this.getResidueColor(atom._residue, complex);
+  }
+
+  getResidueColor(residue, _complex) {
+    return this.palette.getChainColor(residue.getChain()._name);
+  }
 }
 
-utils.deriveClass(ChainColorer, Colorer, {
-  id: 'CH',
-  name: 'Chain',
-  shortName: 'Chain',
-}, {
-  id: 'CH',
-});
-
-ChainColorer.prototype.getAtomColor = function(atom, complex) {
-  return this.getResidueColor(atom._residue, complex);
-};
-
-ChainColorer.prototype.getResidueColor = function(residue, _complex) {
-  return this.palette.getChainColor(residue.getChain()._name);
-};
+ChainColorer.id = 'CH';
+ChainColorer.prototype.id = 'CH';
+ChainColorer.prototype.name = 'Chain';
+ChainColorer.prototype.shortName = 'Chain';
 
 export default ChainColorer;
-

--- a/src/gfx/colorers/ChainColorer.js
+++ b/src/gfx/colorers/ChainColorer.js
@@ -1,8 +1,8 @@
-
-
 import Colorer from './Colorer';
 
 class ChainColorer extends Colorer {
+  static id = 'CH';
+
   constructor(opts) {
     super(opts);
   }
@@ -16,7 +16,6 @@ class ChainColorer extends Colorer {
   }
 }
 
-ChainColorer.id = 'CH';
 ChainColorer.prototype.id = 'CH';
 ChainColorer.prototype.name = 'Chain';
 ChainColorer.prototype.shortName = 'Chain';

--- a/src/gfx/colorers/Colorer.js
+++ b/src/gfx/colorers/Colorer.js
@@ -1,5 +1,3 @@
-
-
 import _ from 'lodash';
 import settings from '../../settings';
 import utils from '../../utils';

--- a/src/gfx/colorers/Colorer.js
+++ b/src/gfx/colorers/Colorer.js
@@ -19,41 +19,43 @@ import palettes from '../palettes';
  * @constructor
  * @classdesc Basic class for all available coloring algorithms used for building and displaying molecule geometry.
  */
-function Colorer(opts) {
-  if (this.constructor === Colorer) {
-    throw new Error('Can not instantiate abstract class!');
+class Colorer {
+  constructor(opts) {
+    if (this.constructor === Colorer) {
+      throw new Error('Can not instantiate abstract class!');
+    }
+    /**
+     * Colorer options inherited (prototyped) from defaults.
+     * @type {object}
+     */
+    this.opts = _.merge(utils.deriveDeep(settings.now.colorers[this.id], true), opts);
+    /**
+     * Palette in use.
+     * @type {Palette}
+     */
+    this.palette = palettes.first;
   }
+
   /**
-   * Colorer options inherited (prototyped) from defaults.
-   * @type {object}
+   * Get Colorer identification, probably with options.
+   * @returns {string|Array} Colorer identifier string ({@link Colorer#id}) or two-element array containing both colorer
+   *   identifier and options ({@link Colorer#opts}).
+   * Options are returned if they were changed during or after colorer creation.
    */
-  this.opts = _.merge(utils.deriveDeep(settings.now.colorers[this.id], true), opts);
-  /**
-   * Palette in use.
-   * @type {Palette}
-   */
-  this.palette = palettes.first;
+  identify() {
+    const diff = utils.objectsDiff(this.opts, settings.now.colorers[this.id]);
+    if (!_.isEmpty(diff)) {
+      return [this.id, diff];
+    }
+    return this.id;
+  }
 }
 
 /**
  * Colorer identifier.
  * @type {string}
  */
+
 Colorer.prototype.id = '__';
 
-/**
- * Get Colorer identification, probably with options.
- * @returns {string|Array} Colorer identifier string ({@link Colorer#id}) or two-element array containing both colorer
- *   identifier and options ({@link Colorer#opts}).
- * Options are returned if they were changed during or after colorer creation.
- */
-Colorer.prototype.identify = function() {
-  var diff = utils.objectsDiff(this.opts, settings.now.colorers[this.id]);
-  if (!_.isEmpty(diff)) {
-    return [this.id, diff];
-  }
-  return this.id;
-};
-
 export default Colorer;
-

--- a/src/gfx/colorers/ConditionalColorer.js
+++ b/src/gfx/colorers/ConditionalColorer.js
@@ -1,5 +1,3 @@
-
-
 import Colorer from './Colorer';
 import selectors from '../../chem/selectors';
 
@@ -15,6 +13,8 @@ import selectors from '../../chem/selectors';
  * @classdesc Bicolor coloring algorithm based on a selector string used as a condition.
  */
 class ConditionalColorer extends Colorer {
+  static id = 'CO';
+
   constructor(opts) {
     super(opts);
     const parsed = selectors.parse(this.opts.subset);
@@ -36,7 +36,6 @@ class ConditionalColorer extends Colorer {
   }
 }
 
-ConditionalColorer.id = 'CO';
 ConditionalColorer.prototype.id = 'CO';
 ConditionalColorer.prototype.name = 'Conditional';
 ConditionalColorer.prototype.shortName = 'Conditional';

--- a/src/gfx/colorers/ConditionalColorer.js
+++ b/src/gfx/colorers/ConditionalColorer.js
@@ -1,8 +1,8 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 import selectors from '../../chem/selectors';
+
 
 /**
  * Create new colorer.
@@ -14,33 +14,31 @@ import selectors from '../../chem/selectors';
  * @constructor
  * @classdesc Bicolor coloring algorithm based on a selector string used as a condition.
  */
-function ConditionalColorer(opts) {
-  Colorer.call(this, opts);
-  var parsed = selectors.parse(this.opts.subset);
-  this._subsetCached = parsed.error ? selectors.none() : parsed.selector;
+class ConditionalColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+    const parsed = selectors.parse(this.opts.subset);
+    this._subsetCached = parsed.error ? selectors.none() : parsed.selector;
+  }
+
+  getAtomColor(atom, _complex) {
+    return this._subsetCached.includesAtom(atom) ? this.opts.color : this.opts.baseColor;
+  }
+
+  getResidueColor(residue, _complex) {
+    const subset = this._subsetCached;
+    let includes = true;
+    const atoms = residue._atoms;
+    for (let i = 0, n = atoms.length; i < n; ++i) {
+      includes = includes && subset.includesAtom(atoms[i]);
+    }
+    return includes ? this.opts.color : this.opts.baseColor;
+  }
 }
 
-utils.deriveClass(ConditionalColorer, Colorer, {
-  id: 'CO',
-  name: 'Conditional',
-  shortName: 'Conditional',
-}, {
-  id: 'CO',
-});
-
-ConditionalColorer.prototype.getAtomColor = function(atom, _complex) {
-  return this._subsetCached.includesAtom(atom) ? this.opts.color : this.opts.baseColor;
-};
-
-ConditionalColorer.prototype.getResidueColor = function(residue, _complex) {
-  var subset = this._subsetCached;
-  var includes = true;
-  var atoms = residue._atoms;
-  for (var i = 0, n = atoms.length; i < n; ++i) {
-    includes = includes && subset.includesAtom(atoms[i]);
-  }
-  return includes ? this.opts.color : this.opts.baseColor;
-};
+ConditionalColorer.id = 'CO';
+ConditionalColorer.prototype.id = 'CO';
+ConditionalColorer.prototype.name = 'Conditional';
+ConditionalColorer.prototype.shortName = 'Conditional';
 
 export default ConditionalColorer;
-

--- a/src/gfx/colorers/ConformationColorer.js
+++ b/src/gfx/colorers/ConformationColorer.js
@@ -1,27 +1,24 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
-function ConformationColorer(opts) {
-  Colorer.call(this, opts);
+class ConformationColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, _complex) {
+    return this.palette.getChainColor(String.fromCharCode(atom._location));
+  }
+
+  getResidueColor(_residue, _complex) {
+    return this.palette.defaultResidueColor;
+  }
 }
 
-utils.deriveClass(ConformationColorer, Colorer, {
-  id: 'CF', // [C]on[F]ormation
-  name: 'Conformation',
-  shortName: 'Conformation',
-}, {
-  id: 'CF',
-});
-
-ConformationColorer.prototype.getAtomColor = function(atom, _complex) {
-  return this.palette.getChainColor(String.fromCharCode(atom._location));
-};
-
-ConformationColorer.prototype.getResidueColor = function(_residue, _complex) {
-  return this.palette.defaultResidueColor;
-};
+ConformationColorer.id = 'CF';
+ConformationColorer.prototype.id = 'CF';
+ConformationColorer.prototype.name = 'Conformation';
+ConformationColorer.prototype.shortName = 'Conformation';
 
 export default ConformationColorer;
-

--- a/src/gfx/colorers/ConformationColorer.js
+++ b/src/gfx/colorers/ConformationColorer.js
@@ -1,8 +1,8 @@
-
-
 import Colorer from './Colorer';
 
 class ConformationColorer extends Colorer {
+  static id = 'CF';
+
   constructor(opts) {
     super(opts);
   }
@@ -16,7 +16,6 @@ class ConformationColorer extends Colorer {
   }
 }
 
-ConformationColorer.id = 'CF';
 ConformationColorer.prototype.id = 'CF';
 ConformationColorer.prototype.name = 'Conformation';
 ConformationColorer.prototype.shortName = 'Conformation';

--- a/src/gfx/colorers/ElementColorer.js
+++ b/src/gfx/colorers/ElementColorer.js
@@ -1,5 +1,3 @@
-
-
 import Colorer from './Colorer';
 
 /**
@@ -15,6 +13,8 @@ import Colorer from './Colorer';
  * @classdesc Coloring algorithm based on chemical element.
  */
 class ElementColorer extends Colorer {
+  static id = ['EL', 'AT']; // 'AT' is @deprecated backward compatibility after renaming [A]tom [T]ype -> [EL]ement
+
   constructor(opts) {
     super(opts);
   }
@@ -32,8 +32,6 @@ class ElementColorer extends Colorer {
   }
 }
 
-ElementColorer.id = ['EL', 'AT']; // 'AT' is @deprecated backward compatibility
-// after renaming [A]tom [T]ype -> [EL]ement
 ElementColorer.prototype.id = 'EL';
 ElementColorer.prototype.aliases = ['AT']; // @deprecated
 ElementColorer.prototype.name = 'Element';

--- a/src/gfx/colorers/ElementColorer.js
+++ b/src/gfx/colorers/ElementColorer.js
@@ -1,6 +1,5 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
 /**
@@ -15,30 +14,29 @@ import Colorer from './Colorer';
  * @constructor
  * @classdesc Coloring algorithm based on chemical element.
  */
-function ElementColorer(opts) {
-  Colorer.call(this, opts);
+class ElementColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, _complex) {
+    const type = atom.element.name;
+    if (type === 'C' && this.opts.carbon >= 0) {
+      return this.opts.carbon;
+    }
+    return this.palette.getElementColor(type);
+  }
+
+  getResidueColor(_residue, _complex) {
+    return this.palette.defaultResidueColor;
+  }
 }
 
-utils.deriveClass(ElementColorer, Colorer, {
-  id: 'EL',
-  aliases: ['AT'], // @deprecated
-  name: 'Element',
-  shortName: 'Element',
-}, {
-  id: ['EL', 'AT'], // 'AT' is @deprecated backward compatibility after renaming [A]tom [T]ype -> [EL]ement
-});
-
-ElementColorer.prototype.getAtomColor = function(atom, _complex) {
-  var type = atom.element.name;
-  if (type === 'C' && this.opts.carbon >= 0) {
-    return this.opts.carbon;
-  }
-  return this.palette.getElementColor(type);
-};
-
-ElementColorer.prototype.getResidueColor = function(_residue, _complex) {
-  return this.palette.defaultResidueColor;
-};
+ElementColorer.id = ['EL', 'AT']; // 'AT' is @deprecated backward compatibility
+// after renaming [A]tom [T]ype -> [EL]ement
+ElementColorer.prototype.id = 'EL';
+ElementColorer.prototype.aliases = ['AT']; // @deprecated
+ElementColorer.prototype.name = 'Element';
+ElementColorer.prototype.shortName = 'Element';
 
 export default ElementColorer;
-

--- a/src/gfx/colorers/HydrophobicityColorer.js
+++ b/src/gfx/colorers/HydrophobicityColorer.js
@@ -1,34 +1,31 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
-function HydrophobicityColorer(opts) {
-  Colorer.call(this, opts);
+class HydrophobicityColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, complex) {
+    return this.getResidueColor(atom._residue, complex);
+  }
+
+  getResidueColor(residue, _complex) {
+    let color = this.palette.defaultResidueColor;
+    if (residue._type.hydrophobicity) {
+      //Kyte Doolitle hydro [-4.5,4.5]->[0.1]
+      const min = -4.5;
+      const max = 4.5;
+      color = this.palette.getGradientColor((residue._type.hydrophobicity - min) / (max - min), this.opts.gradient);
+    }
+    return color;
+  }
 }
 
-utils.deriveClass(HydrophobicityColorer, Colorer, {
-  id: 'HY',
-  name: 'Hydrophobicity',
-  shortName: 'Hydrophobicity',
-}, {
-  id: 'HY',
-});
-
-HydrophobicityColorer.prototype.getAtomColor = function(atom, complex) {
-  return this.getResidueColor(atom._residue, complex);
-};
-
-HydrophobicityColorer.prototype.getResidueColor = function(residue, _complex) {
-  var color = this.palette.defaultResidueColor;
-  if (residue._type.hydrophobicity) {
-    //Kyte Doolitle hydro [-4.5,4.5]->[0.1]
-    var min = -4.5;
-    var max = 4.5;
-    color = this.palette.getGradientColor((residue._type.hydrophobicity - min) / (max - min), this.opts.gradient);
-  }
-  return color;
-};
+HydrophobicityColorer.id = 'HY';
+HydrophobicityColorer.prototype.id = 'HY';
+HydrophobicityColorer.prototype.name = 'Hydrophobicity';
+HydrophobicityColorer.prototype.shortName = 'Hydrophobicity';
 
 export default HydrophobicityColorer;
-

--- a/src/gfx/colorers/HydrophobicityColorer.js
+++ b/src/gfx/colorers/HydrophobicityColorer.js
@@ -1,8 +1,8 @@
-
-
 import Colorer from './Colorer';
 
 class HydrophobicityColorer extends Colorer {
+  static id = 'HY';
+
   constructor(opts) {
     super(opts);
   }
@@ -23,7 +23,6 @@ class HydrophobicityColorer extends Colorer {
   }
 }
 
-HydrophobicityColorer.id = 'HY';
 HydrophobicityColorer.prototype.id = 'HY';
 HydrophobicityColorer.prototype.name = 'Hydrophobicity';
 HydrophobicityColorer.prototype.shortName = 'Hydrophobicity';

--- a/src/gfx/colorers/MoleculeColorer.js
+++ b/src/gfx/colorers/MoleculeColorer.js
@@ -1,32 +1,29 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
-function MoleculeColorer(opts) {
-  Colorer.call(this, opts);
+class MoleculeColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, complex) {
+    return this.getResidueColor(atom._residue, complex);
+  }
+
+  getResidueColor(residue, _complex) {
+    const molecule = residue._molecule;
+    const count = _complex.getMoleculeCount();
+    if (count > 1) {
+      return this.palette.getGradientColor((molecule._index - 1) / (count - 1), this.opts.gradient);
+    }
+    return this.palette.getGradientColor(0, this.opts.gradient);
+  }
 }
 
-utils.deriveClass(MoleculeColorer, Colorer, {
-  id: 'MO',
-  name: 'Molecule',
-  shortName: 'Molecule',
-}, {
-  id: 'MO',
-});
-
-MoleculeColorer.prototype.getAtomColor = function(atom, complex) {
-  return this.getResidueColor(atom._residue, complex);
-};
-
-MoleculeColorer.prototype.getResidueColor = function(residue, _complex) {
-  var molecule = residue._molecule;
-  var count = _complex.getMoleculeCount();
-  if (count > 1) {
-    return this.palette.getGradientColor((molecule._index - 1) / (count - 1), this.opts.gradient);
-  }
-  return this.palette.getGradientColor(0, this.opts.gradient);
-};
+MoleculeColorer.id = 'MO';
+MoleculeColorer.prototype.id = 'MO';
+MoleculeColorer.prototype.name = 'Molecule';
+MoleculeColorer.prototype.shortName = 'Molecule';
 
 export default MoleculeColorer;
-

--- a/src/gfx/colorers/MoleculeColorer.js
+++ b/src/gfx/colorers/MoleculeColorer.js
@@ -1,8 +1,8 @@
-
-
 import Colorer from './Colorer';
 
 class MoleculeColorer extends Colorer {
+  static id = 'MO';
+
   constructor(opts) {
     super(opts);
   }
@@ -21,7 +21,6 @@ class MoleculeColorer extends Colorer {
   }
 }
 
-MoleculeColorer.id = 'MO';
 MoleculeColorer.prototype.id = 'MO';
 MoleculeColorer.prototype.name = 'Molecule';
 MoleculeColorer.prototype.shortName = 'Molecule';

--- a/src/gfx/colorers/OccupancyColorer.js
+++ b/src/gfx/colorers/OccupancyColorer.js
@@ -1,6 +1,5 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
 /**
@@ -15,38 +14,36 @@ import Colorer from './Colorer';
  * @constructor
  * @classdesc Coloring algorithm based on occupancy of chemical element.
  */
-function OccupancyColorer(opts) {
-  Colorer.call(this, opts);
-}
-
-utils.deriveClass(OccupancyColorer, Colorer, {
-  id: 'OC', // [OC]cupancy
-  name: 'Occupancy',
-  shortName: 'Occupancy',
-}, {
-  id: 'OC',
-});
-
-OccupancyColorer.prototype.getAtomColor = function(atom, _complex) {
-  const opts = this.opts;
-  if (atom._occupancy && opts) {
-    const factor = 1 - atom._occupancy;
-    return this.palette.getGradientColor(factor, opts.gradient);
+class OccupancyColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
   }
-  return this.palette.defaultGradientColor;
-};
 
-OccupancyColorer.prototype.getResidueColor = function(residue, _complex) {
-  const opts = this.opts;
-  if (!opts) {
+  getAtomColor(atom, _complex) {
+    const opts = this.opts;
+    if (atom._occupancy && opts) {
+      const factor = 1 - atom._occupancy;
+      return this.palette.getGradientColor(factor, opts.gradient);
+    }
     return this.palette.defaultGradientColor;
   }
-  if (residue.occupancy > 0) {
-    const factor = 1 - residue.occupancy;
-    return this.palette.getGradientColor(factor, opts.gradient);
+
+  getResidueColor(residue, _complex) {
+    const opts = this.opts;
+    if (!opts) {
+      return this.palette.defaultGradientColor;
+    }
+    if (residue.occupancy > 0) {
+      const factor = 1 - residue.occupancy;
+      return this.palette.getGradientColor(factor, opts.gradient);
+    }
+    return this.palette.defaultGradientColor;
   }
-  return this.palette.defaultGradientColor;
-};
+}
+
+OccupancyColorer.id = 'OC';
+OccupancyColorer.prototype.id = 'OC';  //[OC]cupancy
+OccupancyColorer.prototype.name = 'Occupancy';
+OccupancyColorer.prototype.shortName = 'Occupancy';
 
 export default OccupancyColorer;
-

--- a/src/gfx/colorers/OccupancyColorer.js
+++ b/src/gfx/colorers/OccupancyColorer.js
@@ -1,5 +1,3 @@
-
-
 import Colorer from './Colorer';
 
 /**
@@ -15,6 +13,8 @@ import Colorer from './Colorer';
  * @classdesc Coloring algorithm based on occupancy of chemical element.
  */
 class OccupancyColorer extends Colorer {
+  static id = 'OC';
+
   constructor(opts) {
     super(opts);
   }
@@ -41,7 +41,6 @@ class OccupancyColorer extends Colorer {
   }
 }
 
-OccupancyColorer.id = 'OC';
 OccupancyColorer.prototype.id = 'OC';  //[OC]cupancy
 OccupancyColorer.prototype.name = 'Occupancy';
 OccupancyColorer.prototype.shortName = 'Occupancy';

--- a/src/gfx/colorers/ResidueTypeColorer.js
+++ b/src/gfx/colorers/ResidueTypeColorer.js
@@ -1,5 +1,3 @@
-
-
 import Colorer from './Colorer';
 
 /**
@@ -11,6 +9,8 @@ import Colorer from './Colorer';
  * @constructor
  */
 class ResidueTypeColorer extends Colorer {
+  static id = 'RT';
+
   constructor(opts) {
     super(opts);
   }
@@ -24,7 +24,6 @@ class ResidueTypeColorer extends Colorer {
   }
 }
 
-ResidueTypeColorer.id = 'RT';
 ResidueTypeColorer.prototype.id = 'RT';
 ResidueTypeColorer.prototype.name = 'Residue Type';
 ResidueTypeColorer.prototype.shortName = 'Residue';

--- a/src/gfx/colorers/ResidueTypeColorer.js
+++ b/src/gfx/colorers/ResidueTypeColorer.js
@@ -1,6 +1,5 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
 /**
@@ -11,25 +10,23 @@ import Colorer from './Colorer';
  * @exports ResidueTypeColorer
  * @constructor
  */
-function ResidueTypeColorer(opts) {
-  Colorer.call(this, opts);
+class ResidueTypeColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, complex) {
+    return this.getResidueColor(atom._residue, complex);
+  }
+
+  getResidueColor(residue, _complex) {
+    return this.palette.getResidueColor(residue._type._name);
+  }
 }
 
-utils.deriveClass(ResidueTypeColorer, Colorer, {
-  id: 'RT',
-  name: 'Residue Type',
-  shortName: 'Residue',
-}, {
-  id: 'RT',
-});
-
-ResidueTypeColorer.prototype.getAtomColor = function(atom, complex) {
-  return this.getResidueColor(atom._residue, complex);
-};
-
-ResidueTypeColorer.prototype.getResidueColor = function(residue, _complex) {
-  return this.palette.getResidueColor(residue._type._name);
-};
+ResidueTypeColorer.id = 'RT';
+ResidueTypeColorer.prototype.id = 'RT';
+ResidueTypeColorer.prototype.name = 'Residue Type';
+ResidueTypeColorer.prototype.shortName = 'Residue';
 
 export default ResidueTypeColorer;
-

--- a/src/gfx/colorers/SecondaryStructureColorer.js
+++ b/src/gfx/colorers/SecondaryStructureColorer.js
@@ -1,41 +1,38 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 import ResidueType from '../../chem/ResidueType';
 
-function SecondaryStructureColorer(opts) {
-  Colorer.call(this, opts);
+class SecondaryStructureColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, complex) {
+    return this.getResidueColor(atom._residue, complex);
+  }
+
+  getResidueColor(residue, _complex) {
+    if (residue._type.flags & ResidueType.Flags.DNA) {
+      return this.palette.getSecondaryColor('dna');
+    } else if (residue._type.flags & ResidueType.Flags.RNA) {
+      return this.palette.getSecondaryColor('rna');
+    }
+    const secondary = residue.getSecondary();
+    if (secondary) {
+      let color = this.palette.getSecondaryColor(secondary.type, true);
+      if (color === undefined) {
+        color = this.palette.getSecondaryColor(secondary.generic);
+      }
+      return color;
+    }
+    return this.palette.defaultSecondaryColor;
+  }
 }
 
-utils.deriveClass(SecondaryStructureColorer, Colorer, {
-  id: 'SS',
-  name: 'Secondary Structure',
-  shortName: 'Structure',
-}, {
-  id: 'SS',
-});
-
-SecondaryStructureColorer.prototype.getAtomColor = function(atom, complex) {
-  return this.getResidueColor(atom._residue, complex);
-};
-
-SecondaryStructureColorer.prototype.getResidueColor = function(residue, _complex) {
-  if (residue._type.flags & ResidueType.Flags.DNA) {
-    return this.palette.getSecondaryColor('dna');
-  } else if (residue._type.flags & ResidueType.Flags.RNA) {
-    return this.palette.getSecondaryColor('rna');
-  }
-  const secondary = residue.getSecondary();
-  if (secondary) {
-    let color = this.palette.getSecondaryColor(secondary.type, true);
-    if (color === undefined) {
-      color = this.palette.getSecondaryColor(secondary.generic);
-    }
-    return color;
-  }
-  return this.palette.defaultSecondaryColor;
-};
+SecondaryStructureColorer.id = 'SS';
+SecondaryStructureColorer.prototype.id = 'SS';
+SecondaryStructureColorer.prototype.name = 'Secondary Structure';
+SecondaryStructureColorer.prototype.shortName = 'Structure';
 
 export default SecondaryStructureColorer;
-

--- a/src/gfx/colorers/SecondaryStructureColorer.js
+++ b/src/gfx/colorers/SecondaryStructureColorer.js
@@ -1,9 +1,9 @@
-
-
 import Colorer from './Colorer';
 import ResidueType from '../../chem/ResidueType';
 
 class SecondaryStructureColorer extends Colorer {
+  static id = 'SS';
+
   constructor(opts) {
     super(opts);
   }
@@ -30,7 +30,6 @@ class SecondaryStructureColorer extends Colorer {
   }
 }
 
-SecondaryStructureColorer.id = 'SS';
 SecondaryStructureColorer.prototype.id = 'SS';
 SecondaryStructureColorer.prototype.name = 'Secondary Structure';
 SecondaryStructureColorer.prototype.shortName = 'Structure';

--- a/src/gfx/colorers/SequenceColorer.js
+++ b/src/gfx/colorers/SequenceColorer.js
@@ -1,8 +1,8 @@
-
-
 import Colorer from './Colorer';
 
 class SequenceColorer extends Colorer {
+  static id = ['SQ', 'RI']; // 'RI' is @deprecated backward compatibility after renaming [R]esidue [I]d -> [S]e[Q]uence
+
   constructor(opts) {
     super(opts);
   }
@@ -22,8 +22,6 @@ class SequenceColorer extends Colorer {
   }
 }
 
-SequenceColorer.id = ['SQ', 'RI']; // 'RI' is @deprecated backward compatibility
-// after renaming [R]esidue [I]d -> [S]e[Q]uence
 SequenceColorer.prototype.id = 'SQ';
 SequenceColorer.prototype.aliases = ['RI']; // @deprecated;
 SequenceColorer.prototype.name = 'Sequence';

--- a/src/gfx/colorers/SequenceColorer.js
+++ b/src/gfx/colorers/SequenceColorer.js
@@ -1,34 +1,32 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
-function SequenceColorer(opts) {
-  Colorer.call(this, opts);
+class SequenceColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(atom, complex) {
+    return this.getResidueColor(atom._residue, complex);
+  }
+
+  getResidueColor(residue, _complex) {
+    const chain = residue._chain;
+    if (chain.minSequence === Number.POSITIVE_INFINITY && chain.maxSequence === Number.NEGATIVE_INFINITY) {
+      return this.palette.defaultNamedColor;
+    }
+    const min = chain.minSequence;
+    const max = chain.maxSequence > min ? chain.maxSequence : min + 1;
+    return this.palette.getGradientColor((residue._sequence - min) / (max - min), this.opts.gradient);
+  }
 }
 
-utils.deriveClass(SequenceColorer, Colorer, {
-  id: 'SQ',
-  aliases: ['RI'], // @deprecated
-  name: 'Sequence',
-  shortName: 'Sequence',
-}, {
-  id: ['SQ', 'RI'], // 'RI' is @deprecated backward compatibility after renaming [R]esidue [I]d -> [S]e[Q]uence
-});
-
-SequenceColorer.prototype.getAtomColor = function(atom, complex) {
-  return this.getResidueColor(atom._residue, complex);
-};
-
-SequenceColorer.prototype.getResidueColor = function(residue, _complex) {
-  const chain = residue._chain;
-  if (chain.minSequence === Number.POSITIVE_INFINITY && chain.maxSequence === Number.NEGATIVE_INFINITY) {
-    return this.palette.defaultNamedColor;
-  }
-  const min = chain.minSequence;
-  const max = chain.maxSequence > min ? chain.maxSequence : min + 1;
-  return this.palette.getGradientColor((residue._sequence - min) / (max - min), this.opts.gradient);
-};
+SequenceColorer.id = ['SQ', 'RI']; // 'RI' is @deprecated backward compatibility
+// after renaming [R]esidue [I]d -> [S]e[Q]uence
+SequenceColorer.prototype.id = 'SQ';
+SequenceColorer.prototype.aliases = ['RI']; // @deprecated;
+SequenceColorer.prototype.name = 'Sequence';
+SequenceColorer.prototype.shortName = 'Sequence';
 
 export default SequenceColorer;
-

--- a/src/gfx/colorers/TemperatureColorer.js
+++ b/src/gfx/colorers/TemperatureColorer.js
@@ -1,6 +1,5 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
 /**
@@ -15,48 +14,46 @@ import Colorer from './Colorer';
  * @constructor
  * @classdesc Coloring algorithm based on temperature of chemical element.
  */
-function TemperatureColorer(opts) {
-  Colorer.call(this, opts);
-}
-
-utils.deriveClass(TemperatureColorer, Colorer, {
-  id: 'TM', // [T]e[M]perature
-  name: 'Temperature',
-  shortName: 'Temperature',
-}, {
-  id: 'TM',
-});
-
-TemperatureColorer.prototype.getAtomColor = function(atom, _complex) {
-  const opts = this.opts;
-  let factor = 1;
-  if (atom._temperature && opts) {
-    if (opts.min === opts.max) {
-      factor = atom._temperature > opts.max ? 1 : 0;
-    } else {
-      factor = (atom._temperature - opts.min) / (opts.max - opts.min);
-    }
-    return this.palette.getGradientColor(factor, opts.gradient);
+class TemperatureColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
   }
-  return this.palette.defaultGradientColor;
-};
 
-TemperatureColorer.prototype.getResidueColor = function(residue, _complex) {
-  const opts = this.opts;
-  if (!opts) {
+  getAtomColor(atom, _complex) {
+    const opts = this.opts;
+    let factor = 1;
+    if (atom._temperature && opts) {
+      if (opts.min === opts.max) {
+        factor = atom._temperature > opts.max ? 1 : 0;
+      } else {
+        factor = (atom._temperature - opts.min) / (opts.max - opts.min);
+      }
+      return this.palette.getGradientColor(factor, opts.gradient);
+    }
     return this.palette.defaultGradientColor;
   }
-  if (residue.temperature) {
-    let factor = 0;
-    if (opts.min === opts.max) {
-      factor = residue.temperature > opts.max ? 1 : 0;
-    } else {
-      factor = (residue.temperature - opts.min) / (opts.max - opts.min);
+
+  getResidueColor(residue, _complex) {
+    const opts = this.opts;
+    if (!opts) {
+      return this.palette.defaultGradientColor;
     }
-    return this.palette.getGradientColor(factor, opts.gradient);
+    if (residue.temperature) {
+      let factor = 0;
+      if (opts.min === opts.max) {
+        factor = residue.temperature > opts.max ? 1 : 0;
+      } else {
+        factor = (residue.temperature - opts.min) / (opts.max - opts.min);
+      }
+      return this.palette.getGradientColor(factor, opts.gradient);
+    }
+    return this.palette.defaultGradientColor;
   }
-  return this.palette.defaultGradientColor;
-};
+}
+
+TemperatureColorer.id = 'TM';
+TemperatureColorer.prototype.id = 'TM'; // [T]e[M]perature
+TemperatureColorer.prototype.name = 'Temperature';
+TemperatureColorer.prototype.shortName = 'Temperature';
 
 export default TemperatureColorer;
-

--- a/src/gfx/colorers/TemperatureColorer.js
+++ b/src/gfx/colorers/TemperatureColorer.js
@@ -1,5 +1,3 @@
-
-
 import Colorer from './Colorer';
 
 /**
@@ -15,6 +13,8 @@ import Colorer from './Colorer';
  * @classdesc Coloring algorithm based on temperature of chemical element.
  */
 class TemperatureColorer extends Colorer {
+  static id = 'TM';
+
   constructor(opts) {
     super(opts);
   }
@@ -51,7 +51,6 @@ class TemperatureColorer extends Colorer {
   }
 }
 
-TemperatureColorer.id = 'TM';
 TemperatureColorer.prototype.id = 'TM'; // [T]e[M]perature
 TemperatureColorer.prototype.name = 'Temperature';
 TemperatureColorer.prototype.shortName = 'Temperature';

--- a/src/gfx/colorers/UniformColorer.js
+++ b/src/gfx/colorers/UniformColorer.js
@@ -1,8 +1,8 @@
-
-
 import Colorer from './Colorer';
 
 class UniformColorer extends Colorer {
+  static id = 'UN';
+
   constructor(opts) {
     super(opts);
   }
@@ -16,7 +16,6 @@ class UniformColorer extends Colorer {
   }
 }
 
-UniformColorer.id = 'UN';
 UniformColorer.prototype.id = 'UN';
 UniformColorer.prototype.name = 'Uniform';
 UniformColorer.prototype.shortName = 'Uniform';

--- a/src/gfx/colorers/UniformColorer.js
+++ b/src/gfx/colorers/UniformColorer.js
@@ -1,27 +1,24 @@
 
 
-import utils from '../../utils';
 import Colorer from './Colorer';
 
-function UniformColorer(opts) {
-  Colorer.call(this, opts);
+class UniformColorer extends Colorer {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getAtomColor(_atom, _complex) {
+    return this.opts.color;
+  }
+
+  getResidueColor(_residue, _complex) {
+    return this.opts.color;
+  }
 }
 
-utils.deriveClass(UniformColorer, Colorer, {
-  id: 'UN',
-  name: 'Uniform',
-  shortName: 'Uniform',
-}, {
-  id: 'UN',
-});
-
-UniformColorer.prototype.getAtomColor = function(_atom, _complex) {
-  return this.opts.color;
-};
-
-UniformColorer.prototype.getResidueColor = function(_residue, _complex) {
-  return this.opts.color;
-};
+UniformColorer.id = 'UN';
+UniformColorer.prototype.id = 'UN';
+UniformColorer.prototype.name = 'Uniform';
+UniformColorer.prototype.shortName = 'Uniform';
 
 export default UniformColorer;
-

--- a/src/gfx/meshes/MeshCreator.js
+++ b/src/gfx/meshes/MeshCreator.js
@@ -28,8 +28,8 @@ function _createInstancedCylinders(useZSprites, openEnded) {
 }
 
 function _createLineSegmentsGeoTriplet(geo, renderParams) {
-  var thickLines = geo.prototype instanceof ThickLinesGeometry;
-  var lineWidth = renderParams.lineWidth || 0;
+  const thickLines = geo.prototype instanceof ThickLinesGeometry;
+  const lineWidth = renderParams.lineWidth || 0;
   return {
     Geometry: geo,
     Object: thickLines ? meshes.ThickLineMesh : meshes.LineSegments,
@@ -56,7 +56,7 @@ function _createSimpleGeoTriplet(geoClass) {
 }
 
 function _createIsoSurfaceGeoTriplet(geoClass, caps, settings, renderParams) {
-  var surfaceOpts = {
+  const surfaceOpts = {
     wireframe: !!renderParams.wireframe,
     fakeOpacity: settings.now.isoSurfaceFakeOpacity,
     zClip: renderParams.zClip,
@@ -79,7 +79,7 @@ function MeshCreator() {
 }
 
 MeshCreator.createSpheres = function(caps, settings) {
-  var useZSprites = settings.now.zSprites;
+  const useZSprites = settings.now.zSprites;
   return {
     Geometry: function(a, b) {
       return new geometries.InstancedSpheresGeometry(a, b, useZSprites);

--- a/src/gfx/meshes/MeshCreator.js
+++ b/src/gfx/meshes/MeshCreator.js
@@ -1,5 +1,3 @@
-
-
 import geometries from '../geometries/geometries';
 import meshes from './meshes';
 import ThickLinesGeometry from '../geometries/ThickLinesGeometry';
@@ -91,7 +89,7 @@ class MeshCreator {
     };
   }
 
-// TODO thisnk about interface and responsibilities
+  // TODO thisnk about interface and responsibilities
   static create2CClosedCylinders(_caps, _settings) {
     return _createInstancedCylinders(false, false);
   }
@@ -139,4 +137,3 @@ class MeshCreator {
 }
 
 export default MeshCreator;
-

--- a/src/gfx/meshes/MeshCreator.js
+++ b/src/gfx/meshes/MeshCreator.js
@@ -74,70 +74,69 @@ function _createIsoSurfaceGeoTriplet(geoClass, caps, settings, renderParams) {
   };
 }
 
-function MeshCreator() {
-
-}
-
-MeshCreator.createSpheres = function(caps, settings) {
-  const useZSprites = settings.now.zSprites;
-  return {
-    Geometry: function(a, b) {
-      return new geometries.InstancedSpheresGeometry(a, b, useZSprites);
-    },
-    Object: meshes.ZSprite,
-    initMaterial: setMatParams({
-      instancedPos: true,
-      attrColor: true,
-      attrAlphaColor: true,
-      sphereSprite: useZSprites,
-    }),
-  };
-};
+class MeshCreator {
+  static createSpheres(caps, settings) {
+    const useZSprites = settings.now.zSprites;
+    return {
+      Geometry: function(a, b) {
+        return new geometries.InstancedSpheresGeometry(a, b, useZSprites);
+      },
+      Object: meshes.ZSprite,
+      initMaterial: setMatParams({
+        instancedPos: true,
+        attrColor: true,
+        attrAlphaColor: true,
+        sphereSprite: useZSprites,
+      }),
+    };
+  }
 
 // TODO thisnk about interface and responsibilities
-MeshCreator.create2CClosedCylinders = function(_caps, _settings) {
-  return _createInstancedCylinders(false, false);
-};
+  static create2CClosedCylinders(_caps, _settings) {
+    return _createInstancedCylinders(false, false);
+  }
 
-MeshCreator.create2CCylinders = function(caps, settings) {
-  return _createInstancedCylinders(settings.now.zSprites, true);
-};
+  static create2CCylinders(caps, settings) {
+    return _createInstancedCylinders(settings.now.zSprites, true);
+  }
 
-MeshCreator.create2CLines = function(_caps, _settings, renderParams) {
-  return _createLineSegmentsGeoTriplet(geometries.TwoColorLinesGeometry, renderParams);
-};
+  static create2CLines(_caps, _settings, renderParams) {
+    return _createLineSegmentsGeoTriplet(geometries.TwoColorLinesGeometry, renderParams);
+  }
 
-MeshCreator.createCrosses = function(_caps, _settings, renderParams) {
-  return _createLineSegmentsGeoTriplet(geometries.CrossGeometry, renderParams);
-};
+  static createCrosses(_caps, _settings, renderParams) {
+    return _createLineSegmentsGeoTriplet(geometries.CrossGeometry, renderParams);
+  }
 
-MeshCreator.createExtrudedChains = function(_caps, _settings) {
-  return _createSimpleGeoTriplet(geometries.ExtrudedObjectsGeometry);
-};
+  static createExtrudedChains(_caps, _settings) {
+    return _createSimpleGeoTriplet(geometries.ExtrudedObjectsGeometry);
+  }
 
-MeshCreator.createChunkedLines = function(_caps, _settings, renderParams) {
-  return _createLineSegmentsGeoTriplet(geometries.ChunkedLinesGeometry, renderParams);
-};
+  static createChunkedLines(_caps, _settings, renderParams) {
+    return _createLineSegmentsGeoTriplet(geometries.ChunkedLinesGeometry, renderParams);
+  }
 
-MeshCreator.createQuickSurface = function(caps, settings, renderParams) {
-  return _createIsoSurfaceGeoTriplet(geometries.QuickSurfGeometry, caps, settings, renderParams);
-};
+  static createQuickSurface(caps, settings, renderParams) {
+    return _createIsoSurfaceGeoTriplet(geometries.QuickSurfGeometry, caps, settings, renderParams);
+  }
 
-MeshCreator.createContactSurface = function(caps, settings, renderParams) {
-  return _createIsoSurfaceGeoTriplet(geometries.ContactSurfaceGeometry, caps, settings, renderParams);
-};
+  static createContactSurface(caps, settings, renderParams) {
+    return _createIsoSurfaceGeoTriplet(geometries.ContactSurfaceGeometry, caps, settings, renderParams);
+  }
 
-MeshCreator.createSASSES = function(caps, settings, renderParams) {
-  return _createIsoSurfaceGeoTriplet(geometries.SSIsosurfaceGeometry, caps, settings, renderParams);
-};
+  static createSASSES(caps, settings, renderParams) {
+    return _createIsoSurfaceGeoTriplet(geometries.SSIsosurfaceGeometry, caps, settings, renderParams);
+  }
 
-MeshCreator.createLabels = function(_caps, _settings) {
-  return {
-    Geometry: geometries.LabelsGeometry,
-    Object: meshes.Text,
-    initMaterial: function() {},
-  };
-};
+  static createLabels(_caps, _settings) {
+    return {
+      Geometry: geometries.LabelsGeometry,
+      Object: meshes.Text,
+      initMaterial: function() {
+      },
+    };
+  }
+}
 
 export default MeshCreator;
 

--- a/src/gfx/meshes/TextMesh.js
+++ b/src/gfx/meshes/TextMesh.js
@@ -9,7 +9,7 @@ function TextMesh(geometry, _material) {
   THREE.Group.call(this);
   this.geometry = geometry;
 
-  var self = this;
+  let self = this;
   self.initialized = false;
   this.geometry.addEventListener('update', function() {
     self.update();
@@ -20,24 +20,24 @@ TextMesh.prototype = Object.create(THREE.Group.prototype);
 TextMesh.prototype.constructor = TextMesh;
 
 TextMesh.prototype.init = function() {
-  var children = this.children;
-  var i = children.length - 1;
+  const children = this.children;
+  let i = children.length - 1;
   for (; i >= 0; --i) {
     this.remove(children[i]);
   }
 
-  var items = this.geometry.items;
-  var userData = this.geometry.userData;
-  var n = items.length;
+  const items = this.geometry.items;
+  const userData = this.geometry.userData;
+  const n = items.length;
   for (i = 0; i < n; ++i) {
-    var srcItem = items[i];
+    const srcItem = items[i];
     if (!srcItem) {
       continue;
     }
-    var item = utils.shallowCloneNode(srcItem);
-    var label = new CSS2DObject(item);
+    const item = utils.shallowCloneNode(srcItem);
+    const label = new CSS2DObject(item);
     label.userData = _.clone(userData);
-    var el = label.getElement();
+    const el = label.getElement();
     el.style.visibility = 'visible';
     label.source = srcItem;
     this.add(label);
@@ -46,18 +46,18 @@ TextMesh.prototype.init = function() {
 };
 
 TextMesh.prototype.update = function() {
-  var geo = this.geometry;
+  const geo = this.geometry;
   if (!geo.needsUpdate) {
     return;
   }
-  var children = this.children;
+  const children = this.children;
   if (!this.initialized) {
     this.init();
   }
 
-  for (var i = 0, n = children.length; i < n; ++i) {
-    var child = children[i];
-    var item = child.source;
+  for (let i = 0, n = children.length; i < n; ++i) {
+    const child = children[i];
+    const item = child.source;
     child.position.copy(item.worldPos);
     child.userData.color = item.opts.color;
     child.userData.background = item.opts.background;

--- a/src/gfx/meshes/TextMesh.js
+++ b/src/gfx/meshes/TextMesh.js
@@ -5,64 +5,63 @@ import * as THREE from 'three';
 import CSS2DObject from '../CSS2DObject';
 import utils from '../../utils';
 
-function TextMesh(geometry, _material) {
-  THREE.Group.call(this);
-  this.geometry = geometry;
+class TextMesh extends THREE.Group {
+  constructor(geometry, _material) {
+    super();
+    this.geometry = geometry;
 
-  let self = this;
-  self.initialized = false;
-  this.geometry.addEventListener('update', function() {
-    self.update();
-  });
-}
-
-TextMesh.prototype = Object.create(THREE.Group.prototype);
-TextMesh.prototype.constructor = TextMesh;
-
-TextMesh.prototype.init = function() {
-  const children = this.children;
-  let i = children.length - 1;
-  for (; i >= 0; --i) {
-    this.remove(children[i]);
+    let self = this;
+    self.initialized = false;
+    this.geometry.addEventListener('update', function() {
+      self.update();
+    });
   }
 
-  const items = this.geometry.items;
-  const userData = this.geometry.userData;
-  const n = items.length;
-  for (i = 0; i < n; ++i) {
-    const srcItem = items[i];
-    if (!srcItem) {
-      continue;
+  init() {
+    const children = this.children;
+    let i = children.length - 1;
+    for (; i >= 0; --i) {
+      this.remove(children[i]);
     }
-    const item = utils.shallowCloneNode(srcItem);
-    const label = new CSS2DObject(item);
-    label.userData = _.clone(userData);
-    const el = label.getElement();
-    el.style.visibility = 'visible';
-    label.source = srcItem;
-    this.add(label);
-  }
-  this.initialized = true;
-};
 
-TextMesh.prototype.update = function() {
-  const geo = this.geometry;
-  if (!geo.needsUpdate) {
-    return;
-  }
-  const children = this.children;
-  if (!this.initialized) {
-    this.init();
+    const items = this.geometry.items;
+    const userData = this.geometry.userData;
+    const n = items.length;
+    for (i = 0; i < n; ++i) {
+      const srcItem = items[i];
+      if (!srcItem) {
+        continue;
+      }
+      const item = utils.shallowCloneNode(srcItem);
+      const label = new CSS2DObject(item);
+      label.userData = _.clone(userData);
+      const el = label.getElement();
+      el.style.visibility = 'visible';
+      label.source = srcItem;
+      this.add(label);
+    }
+    this.initialized = true;
   }
 
-  for (let i = 0, n = children.length; i < n; ++i) {
-    const child = children[i];
-    const item = child.source;
-    child.position.copy(item.worldPos);
-    child.userData.color = item.opts.color;
-    child.userData.background = item.opts.background;
+  update() {
+    const geo = this.geometry;
+    if (!geo.needsUpdate) {
+      return;
+    }
+    const children = this.children;
+    if (!this.initialized) {
+      this.init();
+    }
+
+    for (let i = 0, n = children.length; i < n; ++i) {
+      const child = children[i];
+      const item = child.source;
+      child.position.copy(item.worldPos);
+      child.userData.color = item.opts.color;
+      child.userData.background = item.opts.background;
+    }
   }
-};
+}
 
 export default TextMesh;
 

--- a/src/gfx/meshes/TextMesh.js
+++ b/src/gfx/meshes/TextMesh.js
@@ -1,5 +1,3 @@
-
-
 import _ from 'lodash';
 import * as THREE from 'three';
 import CSS2DObject from '../CSS2DObject';
@@ -19,15 +17,13 @@ class TextMesh extends THREE.Group {
 
   init() {
     const children = this.children;
-    let i = children.length - 1;
-    for (; i >= 0; --i) {
+    for (let i = 0, n = children.length; i < n; ++i) {
       this.remove(children[i]);
     }
 
     const items = this.geometry.items;
     const userData = this.geometry.userData;
-    const n = items.length;
-    for (i = 0; i < n; ++i) {
+    for (let i = 0, n = items.length; i < n; ++i) {
       const srcItem = items[i];
       if (!srcItem) {
         continue;
@@ -64,4 +60,3 @@ class TextMesh extends THREE.Group {
 }
 
 export default TextMesh;
-

--- a/src/gfx/meshes/TextMesh.js
+++ b/src/gfx/meshes/TextMesh.js
@@ -17,7 +17,7 @@ class TextMesh extends THREE.Group {
 
   init() {
     const children = this.children;
-    for (let i = 0, n = children.length; i < n; ++i) {
+    for (let i = children.length - 1; i >= 0; --i) {
       this.remove(children[i]);
     }
 

--- a/src/gfx/meshes/ThickLineMesh.js
+++ b/src/gfx/meshes/ThickLineMesh.js
@@ -1,5 +1,3 @@
-
-
 import * as THREE from 'three';
 import UberObject from './UberObject';
 const Mesh = UberObject(THREE.Mesh);
@@ -22,4 +20,3 @@ class ThickLineMesh extends Mesh {
 }
 
 export default ThickLineMesh;
-

--- a/src/gfx/meshes/ThickLineMesh.js
+++ b/src/gfx/meshes/ThickLineMesh.js
@@ -2,7 +2,7 @@
 
 import * as THREE from 'three';
 import UberObject from './UberObject';
-var Mesh = UberObject(THREE.Mesh);
+const Mesh = UberObject(THREE.Mesh);
 
 function ThickLineMesh(geometry, material) {
   Mesh.call(this, geometry, material);
@@ -12,13 +12,13 @@ ThickLineMesh.prototype = Object.create(Mesh.prototype);
 ThickLineMesh.prototype.constructor = ThickLineMesh;
 
 ThickLineMesh.prototype._onBeforeRender = function(renderer, scene, camera) {
-  var material = this.material;
+  const material = this.material;
   if (!material.uberOptions) {
     return;
   }
 
   material.uberOptions.projMatrixInv.getInverse(camera.projectionMatrix, true);
-  var viewport = renderer.getSize();
+  const viewport = renderer.getSize();
   material.uberOptions.viewport.set(viewport.width, viewport.height);
 };
 

--- a/src/gfx/meshes/ThickLineMesh.js
+++ b/src/gfx/meshes/ThickLineMesh.js
@@ -4,23 +4,22 @@ import * as THREE from 'three';
 import UberObject from './UberObject';
 const Mesh = UberObject(THREE.Mesh);
 
-function ThickLineMesh(geometry, material) {
-  Mesh.call(this, geometry, material);
-}
-
-ThickLineMesh.prototype = Object.create(Mesh.prototype);
-ThickLineMesh.prototype.constructor = ThickLineMesh;
-
-ThickLineMesh.prototype._onBeforeRender = function(renderer, scene, camera) {
-  const material = this.material;
-  if (!material.uberOptions) {
-    return;
+class ThickLineMesh extends Mesh {
+  constructor(geometry, material) {
+    super(geometry, material);
   }
 
-  material.uberOptions.projMatrixInv.getInverse(camera.projectionMatrix, true);
-  const viewport = renderer.getSize();
-  material.uberOptions.viewport.set(viewport.width, viewport.height);
-};
+  _onBeforeRender(renderer, scene, camera) {
+    const material = this.material;
+    if (!material.uberOptions) {
+      return;
+    }
+
+    material.uberOptions.projMatrixInv.getInverse(camera.projectionMatrix, true);
+    const viewport = renderer.getSize();
+    material.uberOptions.viewport.set(viewport.width, viewport.height);
+  }
+}
 
 export default ThickLineMesh;
 

--- a/src/gfx/meshes/TransformGroup.js
+++ b/src/gfx/meshes/TransformGroup.js
@@ -1,5 +1,3 @@
-
-
 import * as THREE from 'three';
 
 class TransformGroup extends THREE.Object3D {
@@ -22,15 +20,17 @@ class TransformGroup extends THREE.Object3D {
   }
 
   raycast(raycaster, intersects) {
+    const ray = TransformGroup._ray;
+    const inverseMatrix = TransformGroup._inverseMatrix;
     const children = this.children;
-    TransformGroup._ray.copy(raycaster.ray);
+    ray.copy(raycaster.ray);
     for (let i = 0, n = children.length; i < n; ++i) {
       const child = children[i];
       child.updateMatrixWorld();
       const mtx = child.matrixWorld;
       // TODO check near / far?
-      TransformGroup._inverseMatrix.getInverse(mtx);
-      raycaster.ray.copy(TransformGroup._ray).applyMatrix4(TransformGroup._inverseMatrix);
+      inverseMatrix.getInverse(mtx);
+      raycaster.ray.copy(ray).applyMatrix4(inverseMatrix);
       const childIntersects = [];
       this._geometry.raycast(raycaster, childIntersects);
 
@@ -38,14 +38,14 @@ class TransformGroup extends THREE.Object3D {
         const inters = childIntersects[j];
         if (inters.point) {
           inters.point.applyMatrix4(mtx);
-          inters.distance = TransformGroup._ray.origin.distanceTo(inters.point);
+          inters.distance = ray.origin.distanceTo(inters.point);
         }
         inters.object = child;
         // TODO: check raycaster near/far?
         intersects[intersects.length] = inters;
       }
     }
-    raycaster.ray.copy(TransformGroup._ray);
+    raycaster.ray.copy(ray);
   }
 
   getSubset(chunkIndices) {
@@ -80,4 +80,3 @@ class TransformGroup extends THREE.Object3D {
 }
 
 export default TransformGroup;
-

--- a/src/gfx/meshes/TransformGroup.js
+++ b/src/gfx/meshes/TransformGroup.js
@@ -5,12 +5,12 @@ function TransformGroup(geometry, geoParams, material, transforms) {
   THREE.Object3D.call(this);
   this._geometry = geometry;
   this._geoParams = geoParams;
-  var mat = material.createInstance();
+  const mat = material.createInstance();
   geoParams.initMaterial(mat);
   this._material = mat;
   this._transforms = transforms.length > 0 ? transforms : [new THREE.Matrix4()];
-  var meshes = this._createMeshes(geometry);
-  for (var i = 0, n = meshes.length; i < n; ++i) {
+  const meshes = this._createMeshes(geometry);
+  for (let i = 0, n = meshes.length; i < n; ++i) {
     this.add(meshes[i]);
   }
 }
@@ -19,24 +19,24 @@ TransformGroup.prototype = Object.create(THREE.Object3D.prototype);
 TransformGroup.prototype.constructor = TransformGroup;
 
 TransformGroup.prototype.raycast = (function() {
-  var inverseMatrix = new THREE.Matrix4();
-  var ray = new THREE.Ray();
+  const inverseMatrix = new THREE.Matrix4();
+  const ray = new THREE.Ray();
 
   return function(raycaster, intersects) {
-    var children   = this.children;
+    const children   = this.children;
     ray.copy(raycaster.ray);
-    for (var i = 0, n = children.length; i < n; ++i) {
-      var child = children[i];
+    for (let i = 0, n = children.length; i < n; ++i) {
+      const child = children[i];
       child.updateMatrixWorld();
-      var mtx = child.matrixWorld;
+      const mtx = child.matrixWorld;
       // TODO check near / far?
       inverseMatrix.getInverse(mtx);
       raycaster.ray.copy(ray).applyMatrix4(inverseMatrix);
-      var childIntersects = [];
+      const childIntersects = [];
       this._geometry.raycast(raycaster, childIntersects);
 
-      for (var j = 0, ciCount = childIntersects.length; j < ciCount; ++j) {
-        var inters = childIntersects[j];
+      for (let j = 0, ciCount = childIntersects.length; j < ciCount; ++j) {
+        const inters = childIntersects[j];
         if (inters.point) {
           inters.point.applyMatrix4(mtx);
           inters.distance = ray.origin.distanceTo(inters.point);
@@ -51,13 +51,13 @@ TransformGroup.prototype.raycast = (function() {
 })();
 
 TransformGroup.prototype.getSubset = function(chunkIndices) {
-  var geos = this._geometry.getSubset(chunkIndices);
-  var subset = [];
-  var subIdx = 0;
+  const geos = this._geometry.getSubset(chunkIndices);
+  const subset = [];
+  let subIdx = 0;
 
-  for (var i = 0, n = geos.length; i < n; ++i) {
-    var meshes = this._createMeshes(geos[i]);
-    for (var j = 0, meshCnt = meshes.length; j < meshCnt; ++j) {
+  for (let i = 0, n = geos.length; i < n; ++i) {
+    const meshes = this._createMeshes(geos[i]);
+    for (let j = 0, meshCnt = meshes.length; j < meshCnt; ++j) {
       subset[subIdx++] = meshes[j];
     }
   }
@@ -66,12 +66,12 @@ TransformGroup.prototype.getSubset = function(chunkIndices) {
 };
 
 TransformGroup.prototype._createMeshes = function(geometry) {
-  var transforms = this._transforms;
-  var Mesh = this._geoParams.Object;
-  var material = this._material;
-  var meshes = [];
-  for (var i = 0, n = transforms.length; i < n; ++i) {
-    var mesh = new Mesh(geometry, material);
+  const transforms = this._transforms;
+  const Mesh = this._geoParams.Object;
+  const material = this._material;
+  const meshes = [];
+  for (let i = 0, n = transforms.length; i < n; ++i) {
+    const mesh = new Mesh(geometry, material);
     mesh.applyMatrix(transforms[i]);
 
     meshes[i] = mesh;

--- a/src/gfx/meshes/TransformGroup.js
+++ b/src/gfx/meshes/TransformGroup.js
@@ -1,37 +1,36 @@
 
 
 import * as THREE from 'three';
-function TransformGroup(geometry, geoParams, material, transforms) {
-  THREE.Object3D.call(this);
-  this._geometry = geometry;
-  this._geoParams = geoParams;
-  const mat = material.createInstance();
-  geoParams.initMaterial(mat);
-  this._material = mat;
-  this._transforms = transforms.length > 0 ? transforms : [new THREE.Matrix4()];
-  const meshes = this._createMeshes(geometry);
-  for (let i = 0, n = meshes.length; i < n; ++i) {
-    this.add(meshes[i]);
+
+class TransformGroup extends THREE.Object3D {
+  static _inverseMatrix = new THREE.Matrix4();
+
+  static _ray = new THREE.Ray();
+
+  constructor(geometry, geoParams, material, transforms) {
+    super();
+    this._geometry = geometry;
+    this._geoParams = geoParams;
+    const mat = material.createInstance();
+    geoParams.initMaterial(mat);
+    this._material = mat;
+    this._transforms = transforms.length > 0 ? transforms : [new THREE.Matrix4()];
+    const meshes = this._createMeshes(geometry);
+    for (let i = 0, n = meshes.length; i < n; ++i) {
+      this.add(meshes[i]);
+    }
   }
-}
 
-TransformGroup.prototype = Object.create(THREE.Object3D.prototype);
-TransformGroup.prototype.constructor = TransformGroup;
-
-TransformGroup.prototype.raycast = (function() {
-  const inverseMatrix = new THREE.Matrix4();
-  const ray = new THREE.Ray();
-
-  return function(raycaster, intersects) {
-    const children   = this.children;
-    ray.copy(raycaster.ray);
+  raycast(raycaster, intersects) {
+    const children = this.children;
+    TransformGroup._ray.copy(raycaster.ray);
     for (let i = 0, n = children.length; i < n; ++i) {
       const child = children[i];
       child.updateMatrixWorld();
       const mtx = child.matrixWorld;
       // TODO check near / far?
-      inverseMatrix.getInverse(mtx);
-      raycaster.ray.copy(ray).applyMatrix4(inverseMatrix);
+      TransformGroup._inverseMatrix.getInverse(mtx);
+      raycaster.ray.copy(TransformGroup._ray).applyMatrix4(TransformGroup._inverseMatrix);
       const childIntersects = [];
       this._geometry.raycast(raycaster, childIntersects);
 
@@ -39,46 +38,46 @@ TransformGroup.prototype.raycast = (function() {
         const inters = childIntersects[j];
         if (inters.point) {
           inters.point.applyMatrix4(mtx);
-          inters.distance = ray.origin.distanceTo(inters.point);
+          inters.distance = TransformGroup._ray.origin.distanceTo(inters.point);
         }
         inters.object = child;
         // TODO: check raycaster near/far?
         intersects[intersects.length] = inters;
       }
     }
-    raycaster.ray.copy(ray);
-  };
-})();
+    raycaster.ray.copy(TransformGroup._ray);
+  }
 
-TransformGroup.prototype.getSubset = function(chunkIndices) {
-  const geos = this._geometry.getSubset(chunkIndices);
-  const subset = [];
-  let subIdx = 0;
+  getSubset(chunkIndices) {
+    const geos = this._geometry.getSubset(chunkIndices);
+    const subset = [];
+    let subIdx = 0;
 
-  for (let i = 0, n = geos.length; i < n; ++i) {
-    const meshes = this._createMeshes(geos[i]);
-    for (let j = 0, meshCnt = meshes.length; j < meshCnt; ++j) {
-      subset[subIdx++] = meshes[j];
+    for (let i = 0, n = geos.length; i < n; ++i) {
+      const meshes = this._createMeshes(geos[i]);
+      for (let j = 0, meshCnt = meshes.length; j < meshCnt; ++j) {
+        subset[subIdx++] = meshes[j];
+      }
     }
+
+    return subset;
   }
 
-  return subset;
-};
+  _createMeshes(geometry) {
+    const transforms = this._transforms;
+    const Mesh = this._geoParams.Object;
+    const material = this._material;
+    const meshes = [];
+    for (let i = 0, n = transforms.length; i < n; ++i) {
+      const mesh = new Mesh(geometry, material);
+      mesh.applyMatrix(transforms[i]);
 
-TransformGroup.prototype._createMeshes = function(geometry) {
-  const transforms = this._transforms;
-  const Mesh = this._geoParams.Object;
-  const material = this._material;
-  const meshes = [];
-  for (let i = 0, n = transforms.length; i < n; ++i) {
-    const mesh = new Mesh(geometry, material);
-    mesh.applyMatrix(transforms[i]);
+      meshes[i] = mesh;
+    }
 
-    meshes[i] = mesh;
+    return meshes;
   }
-
-  return meshes;
-};
+}
 
 export default TransformGroup;
 

--- a/src/gfx/meshes/UberObject.js
+++ b/src/gfx/meshes/UberObject.js
@@ -2,33 +2,32 @@
 
 import UberMaterial from '../shaders/UberMaterial';
 export default function(SuperClass) {
-  function NewObjectType() {
-    SuperClass.apply(this, arguments);
-    this.onBeforeRender = NewObjectType.prototype.onBeforeRender;
+  class NewObjectType extends SuperClass {
+    constructor(...rest) {
+      super(...rest);
+      this.onBeforeRender = NewObjectType.prototype.onBeforeRender;
+    }
+
+    onBeforeRender(renderer, scene, camera, geometry, material, group) {
+      this._onBeforeRender(renderer, scene, camera, geometry, material, group);
+      this._update();
+    }
+
+    _onBeforeRender() {
+
+    }
+
+    _update() {
+      const material = this.material;
+      if (!material) {
+        return;
+      }
+
+      if (material instanceof UberMaterial) {
+        material.updateUniforms();
+      }
+    }
   }
-
-  NewObjectType.prototype = Object.create(SuperClass.prototype);
-  NewObjectType.prototype.constructor = NewObjectType;
-
-  NewObjectType.prototype.onBeforeRender = function(renderer, scene, camera, geometry, material, group) {
-    this._onBeforeRender(renderer, scene, camera, geometry, material, group);
-    this._update();
-  };
-
-  NewObjectType.prototype._onBeforeRender = function() {
-
-  };
-
-  NewObjectType.prototype._update = function() {
-    const material = this.material;
-    if (!material) {
-      return;
-    }
-
-    if (material instanceof UberMaterial) {
-      material.updateUniforms();
-    }
-  };
 
   return NewObjectType;
 }

--- a/src/gfx/meshes/UberObject.js
+++ b/src/gfx/meshes/UberObject.js
@@ -20,7 +20,7 @@ export default function(SuperClass) {
   };
 
   NewObjectType.prototype._update = function() {
-    var material = this.material;
+    const material = this.material;
     if (!material) {
       return;
     }

--- a/src/gfx/meshes/UberObject.js
+++ b/src/gfx/meshes/UberObject.js
@@ -1,5 +1,3 @@
-
-
 import UberMaterial from '../shaders/UberMaterial';
 export default function(SuperClass) {
   class NewObjectType extends SuperClass {
@@ -31,4 +29,3 @@ export default function(SuperClass) {
 
   return NewObjectType;
 }
-

--- a/src/gfx/meshes/ZClippedMesh.js
+++ b/src/gfx/meshes/ZClippedMesh.js
@@ -1,5 +1,3 @@
-
-
 import * as THREE from 'three';
 import UberObject from './UberObject';
 const Mesh = UberObject(THREE.Mesh);
@@ -30,4 +28,3 @@ class ZClippedMesh extends Mesh {
 }
 
 export default ZClippedMesh;
-

--- a/src/gfx/meshes/ZClippedMesh.js
+++ b/src/gfx/meshes/ZClippedMesh.js
@@ -2,7 +2,7 @@
 
 import * as THREE from 'three';
 import UberObject from './UberObject';
-var Mesh = UberObject(THREE.Mesh);
+const Mesh = UberObject(THREE.Mesh);
 
 function ZClippedMesh(geometry, material) {
   Mesh.call(this, geometry, material);
@@ -12,19 +12,19 @@ ZClippedMesh.prototype = Object.create(Mesh.prototype);
 ZClippedMesh.prototype.constructor = ZClippedMesh;
 
 ZClippedMesh.prototype._onBeforeRender = function(renderer, scene, camera) {
-  var geo = this.geometry;
-  var material = this.material;
+  const geo = this.geometry;
+  const material = this.material;
   if (!geo.zClip || !material.uberOptions) {
     return;
   }
 
-  var zClipCoef = 0.5;
+  const zClipCoef = 0.5;
   // TODO remove these instantiations
-  var modelView = new THREE.Matrix4().multiplyMatrices(this.matrixWorld, camera.matrixWorldInverse);
-  var scale = new THREE.Vector3().setFromMatrixColumn(modelView, 0);
-  var s = scale.length();
+  const modelView = new THREE.Matrix4().multiplyMatrices(this.matrixWorld, camera.matrixWorldInverse);
+  const scale = new THREE.Vector3().setFromMatrixColumn(modelView, 0);
+  const s = scale.length();
 
-  var center = new THREE.Vector3().copy(geo.boundingSphere.center);
+  const center = new THREE.Vector3().copy(geo.boundingSphere.center);
   this.localToWorld(center);
   material.uberOptions.zClipValue = camera.position.z - center.z -
       s * (zClipCoef * geo.boundingSphere.radius);

--- a/src/gfx/meshes/ZClippedMesh.js
+++ b/src/gfx/meshes/ZClippedMesh.js
@@ -4,31 +4,30 @@ import * as THREE from 'three';
 import UberObject from './UberObject';
 const Mesh = UberObject(THREE.Mesh);
 
-function ZClippedMesh(geometry, material) {
-  Mesh.call(this, geometry, material);
-}
-
-ZClippedMesh.prototype = Object.create(Mesh.prototype);
-ZClippedMesh.prototype.constructor = ZClippedMesh;
-
-ZClippedMesh.prototype._onBeforeRender = function(renderer, scene, camera) {
-  const geo = this.geometry;
-  const material = this.material;
-  if (!geo.zClip || !material.uberOptions) {
-    return;
+class ZClippedMesh extends Mesh {
+  constructor(geometry, material) {
+    super(geometry, material);
   }
 
-  const zClipCoef = 0.5;
-  // TODO remove these instantiations
-  const modelView = new THREE.Matrix4().multiplyMatrices(this.matrixWorld, camera.matrixWorldInverse);
-  const scale = new THREE.Vector3().setFromMatrixColumn(modelView, 0);
-  const s = scale.length();
+  _onBeforeRender(renderer, scene, camera) {
+    const geo = this.geometry;
+    const material = this.material;
+    if (!geo.zClip || !material.uberOptions) {
+      return;
+    }
 
-  const center = new THREE.Vector3().copy(geo.boundingSphere.center);
-  this.localToWorld(center);
-  material.uberOptions.zClipValue = camera.position.z - center.z -
+    const zClipCoef = 0.5;
+    // TODO remove these instantiations
+    const modelView = new THREE.Matrix4().multiplyMatrices(this.matrixWorld, camera.matrixWorldInverse);
+    const scale = new THREE.Vector3().setFromMatrixColumn(modelView, 0);
+    const s = scale.length();
+
+    const center = new THREE.Vector3().copy(geo.boundingSphere.center);
+    this.localToWorld(center);
+    material.uberOptions.zClipValue = camera.position.z - center.z -
       s * (zClipCoef * geo.boundingSphere.radius);
-};
+  }
+}
 
 export default ZClippedMesh;
 

--- a/src/gfx/meshes/ZSpriteMesh.js
+++ b/src/gfx/meshes/ZSpriteMesh.js
@@ -1,5 +1,3 @@
-
-
 import * as THREE from 'three';
 import UberObject from './UberObject';
 const Mesh = UberObject(THREE.Mesh);
@@ -27,4 +25,3 @@ class ZSpriteMesh extends Mesh {
 }
 
 export default ZSpriteMesh;
-

--- a/src/gfx/meshes/ZSpriteMesh.js
+++ b/src/gfx/meshes/ZSpriteMesh.js
@@ -2,7 +2,7 @@
 
 import * as THREE from 'three';
 import UberObject from './UberObject';
-var Mesh = UberObject(THREE.Mesh);
+const Mesh = UberObject(THREE.Mesh);
 
 function ZSpriteMesh(geometry, material) {
   Mesh.call(this, geometry, material);
@@ -12,7 +12,7 @@ ZSpriteMesh.prototype = Object.create(Mesh.prototype);
 ZSpriteMesh.prototype.constructor = ZSpriteMesh;
 
 ZSpriteMesh.prototype._onBeforeRender = function(_renderer, _scene, camera, _geometry, _material, _group) {
-  var material = this.material;
+  const material = this.material;
   if (!material) {
     return;
   }

--- a/src/gfx/meshes/ZSpriteMesh.js
+++ b/src/gfx/meshes/ZSpriteMesh.js
@@ -4,28 +4,27 @@ import * as THREE from 'three';
 import UberObject from './UberObject';
 const Mesh = UberObject(THREE.Mesh);
 
-function ZSpriteMesh(geometry, material) {
-  Mesh.call(this, geometry, material);
+class ZSpriteMesh extends Mesh {
+  constructor(geometry, material) {
+    super(geometry, material);
+  }
+
+  _onBeforeRender(_renderer, _scene, camera, _geometry, _material, _group) {
+    const material = this.material;
+    if (!material) {
+      return;
+    }
+
+    if (material.uniforms.invModelViewMatrix) {
+      // NOTE: update of modelViewMatrix inside threejs is done after onBeforeRender call,
+      // so we have to do it manually in that place
+      this.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, this.matrixWorld);
+      // get inverse matrix
+      material.uniforms.invModelViewMatrix.value.getInverse(this.modelViewMatrix);
+      material.uniformsNeedUpdate = true;
+    }
+  }
 }
-
-ZSpriteMesh.prototype = Object.create(Mesh.prototype);
-ZSpriteMesh.prototype.constructor = ZSpriteMesh;
-
-ZSpriteMesh.prototype._onBeforeRender = function(_renderer, _scene, camera, _geometry, _material, _group) {
-  const material = this.material;
-  if (!material) {
-    return;
-  }
-
-  if (material.uniforms.invModelViewMatrix) {
-    // NOTE: update of modelViewMatrix inside threejs is done after onBeforeRender call,
-    // so we have to do it manually in that place
-    this.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, this.matrixWorld);
-    // get inverse matrix
-    material.uniforms.invModelViewMatrix.value.getInverse(this.modelViewMatrix);
-    material.uniformsNeedUpdate = true;
-  }
-};
 
 export default ZSpriteMesh;
 

--- a/src/gfx/meshes/meshes.js
+++ b/src/gfx/meshes/meshes.js
@@ -1,5 +1,3 @@
-
-
 import * as THREE from 'three';
 import UberObject from './UberObject';
 import ZSpriteMesh from './ZSpriteMesh';
@@ -15,4 +13,3 @@ export default {
   Mesh: UberObject(THREE.Mesh),
   ThickLineMesh: ThickLineMesh
 };
-

--- a/src/gfx/modes/BallsAndSticksMode.js
+++ b/src/gfx/modes/BallsAndSticksMode.js
@@ -1,62 +1,61 @@
 
 
 /* eslint-disable no-magic-numbers */
-import utils from '../../utils';
 import LabeledMode from './LabeledMode';
 
-function BallsAndSticksMode(opts) {
-  LabeledMode.call(this, opts);
+class BallsAndSticksMode extends LabeledMode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  calcAtomRadius(atom) {
+    return atom.element.radius * this.opts.atom;
+  }
+
+  calcStickRadius() {
+    return this.opts.bond;
+  }
+
+  getAromRadius() {
+    return this.opts.aromrad;
+  }
+
+  showAromaticLoops() {
+    return this.opts.showarom;
+  }
+
+  calcSpaceFraction() {
+    return this.opts.space;
+  }
+
+  drawMultiorderBonds() {
+    return this.opts.multibond;
+  }
+
+  /** @deprecated Old-fashioned atom labels, to be removed in the next major version. */
+
+  getLabelOpts() {
+    return {
+      fg: 'none',
+      bg: '0x202020',
+      showBg: false,
+      labels: this.settings.now.labels,
+      colors: true,
+      adjustColor: true,
+      transparent: true,
+    };
+  }
 }
 
-utils.deriveClass(BallsAndSticksMode, LabeledMode, {
-  id: 'BS',
-  name: 'Balls and Sticks',
-  shortName: 'Balls',
-  depGroups: [
-    'AtomsSpheres',
-    'BondsCylinders',
-    'ALoopsTorus',
-  ],
-}, {
-  id: 'BS',
-});
-
-BallsAndSticksMode.prototype.calcAtomRadius = function(atom) {
-  return atom.element.radius * this.opts.atom;
-};
-
-BallsAndSticksMode.prototype.calcStickRadius = function() {
-  return this.opts.bond;
-};
-
-BallsAndSticksMode.prototype.getAromRadius = function() {
-  return this.opts.aromrad;
-};
-
-BallsAndSticksMode.prototype.showAromaticLoops = function() {
-  return this.opts.showarom;
-};
-
-BallsAndSticksMode.prototype.calcSpaceFraction = function() {
-  return this.opts.space;
-};
-
-BallsAndSticksMode.prototype.drawMultiorderBonds = function() {
-  return this.opts.multibond;
-};
-
-/** @deprecated Old-fashioned atom labels, to be removed in the next major version. */
-BallsAndSticksMode.prototype.getLabelOpts = function() {
-  return {
-    fg: 'none',
-    bg: '0x202020',
-    showBg: false,
-    labels: this.settings.now.labels,
-    colors: true,
-    adjustColor: true,
-    transparent: true,
-  };
-};
+BallsAndSticksMode.id = 'BS';
+BallsAndSticksMode.prototype.id = 'BS';
+BallsAndSticksMode.prototype.name = 'Balls and Sticks';
+BallsAndSticksMode.prototype.shortName = 'Balls';
+BallsAndSticksMode.prototype.depGroups = [
+  'AtomsSpheres',
+  'BondsCylinders',
+  'ALoopsTorus',
+];
 
 export default BallsAndSticksMode;
 

--- a/src/gfx/modes/BallsAndSticksMode.js
+++ b/src/gfx/modes/BallsAndSticksMode.js
@@ -1,9 +1,9 @@
-
-
 /* eslint-disable no-magic-numbers */
 import LabeledMode from './LabeledMode';
 
 class BallsAndSticksMode extends LabeledMode {
+  static id = 'BS';
+
   constructor(opts) {
     super(opts);
   }
@@ -47,7 +47,6 @@ class BallsAndSticksMode extends LabeledMode {
   }
 }
 
-BallsAndSticksMode.id = 'BS';
 BallsAndSticksMode.prototype.id = 'BS';
 BallsAndSticksMode.prototype.name = 'Balls and Sticks';
 BallsAndSticksMode.prototype.shortName = 'Balls';
@@ -58,4 +57,3 @@ BallsAndSticksMode.prototype.depGroups = [
 ];
 
 export default BallsAndSticksMode;
-

--- a/src/gfx/modes/CartoonMode.js
+++ b/src/gfx/modes/CartoonMode.js
@@ -1,9 +1,9 @@
-
-
 import * as THREE from 'three';
 import Mode from './Mode';
 
 class CartoonMode extends Mode {
+  static id = 'CA';
+
   constructor(opts) {
     super(opts);
     // cache for secondary structure options
@@ -77,7 +77,7 @@ class CartoonMode extends Mode {
     const secCache = {};
     const secData = this.opts.ss;
     /* eslint-disable guard-for-in */
-    for (var prop in secData) {
+    for (let prop in secData) {
       secCache[prop] = {
         center: new THREE.Vector2(secHeight, secData[prop].width),
         start: new THREE.Vector2(secHeight, secData[prop].arrow)
@@ -90,7 +90,6 @@ class CartoonMode extends Mode {
   }
 }
 
-CartoonMode.id = 'CA';
 CartoonMode.prototype.id = 'CA';
 CartoonMode.prototype.name = 'Cartoon';
 CartoonMode.prototype.shortName = 'Cartoon';
@@ -101,4 +100,3 @@ CartoonMode.prototype.depGroups = [
 ];
 
 export default CartoonMode;
-

--- a/src/gfx/modes/CartoonMode.js
+++ b/src/gfx/modes/CartoonMode.js
@@ -1,105 +1,104 @@
 
 
 import * as THREE from 'three';
-import utils from '../../utils';
 import Mode from './Mode';
 
-function CartoonMode(opts) {
-  Mode.call(this, opts);
-  // cache for secondary structure options
-  this.secCache = {};
+class CartoonMode extends Mode {
+  constructor(opts) {
+    super(opts);
+    // cache for secondary structure options
+    this.secCache = {};
+  }
+
+  getResidueStartRadius(residue) {
+    var second = residue.getSecondary();
+    if (!second || !second.generic) {
+      return this.TUBE_RADIUS;
+    }
+    var secOpts = this.secCache[second.generic];
+    if (!secOpts) {
+      return this.TUBE_RADIUS;
+    }
+    if (second.term === residue) {
+      return secOpts.start;
+    }
+    return secOpts.center;
+  }
+
+  getResidueEndRadius(residue) {
+    var second = residue.getSecondary();
+    if (second === null || !second.generic) {
+      return this.TUBE_RADIUS;
+    }
+    var secOpts = this.secCache[second.generic];
+    if (!secOpts) {
+      return this.TUBE_RADIUS;
+    }
+    if (second.term === residue) {
+      return this.ARROW_END;
+    }
+    return secOpts.center;
+  }
+
+  getResidueRadius(residue, val) {
+    var startRad = this.getResidueStartRadius(residue);
+    if (val === 0) {
+      return startRad;
+    }
+
+    var endRad = this.getResidueEndRadius(residue);
+    if (val === 2) {
+      return endRad;
+    }
+
+    return startRad.clone().lerp(endRad, val / 2.0);
+  }
+
+  // TODO: remove when selection is rendered with actual geometry
+
+  calcStickRadius(_res) {
+    return this.opts.radius;
+  }
+
+  getHeightSegmentsRatio() {
+    return this.opts.heightSegmentsRatio;
+  }
+
+  getTension() {
+    return this.opts.tension;
+  }
+
+  buildGeometry(complex, colorer, mask, material) {
+    var tubeRad = this.opts.radius;
+    var secHeight = this.opts.depth;
+
+    this.TUBE_RADIUS = new THREE.Vector2(tubeRad, tubeRad);
+    this.ARROW_END = new THREE.Vector2(secHeight, tubeRad);
+    var secCache = {};
+    var secData = this.opts.ss;
+    /* eslint-disable guard-for-in */
+    for (var prop in secData) {
+      secCache[prop] = {
+        center: new THREE.Vector2(secHeight, secData[prop].width),
+        start: new THREE.Vector2(secHeight, secData[prop].arrow)
+      };
+    }
+    this.secCache = secCache;
+    /* eslint-enable guard-for-in */
+
+    return Mode.prototype.buildGeometry.call(this, complex, colorer, mask, material);
+  }
 }
 
-utils.deriveClass(CartoonMode, Mode, {
-  id: 'CA',
-  name: 'Cartoon',
-  shortName: 'Cartoon',
-  depGroups: [
-    'CartoonChains',
-    'NucleicSpheres',
-    'NucleicCylinders',
-  ],
-}, {
-  id: 'CA',
-});
-
-CartoonMode.prototype.getResidueStartRadius = function(residue) {
-  var second = residue.getSecondary();
-  if (!second || !second.generic) {
-    return this.TUBE_RADIUS;
-  }
-  var secOpts = this.secCache[second.generic];
-  if (!secOpts) {
-    return this.TUBE_RADIUS;
-  }
-  if (second.term === residue) {
-    return secOpts.start;
-  }
-  return secOpts.center;
-};
-
-CartoonMode.prototype.getResidueEndRadius = function(residue) {
-  var second = residue.getSecondary();
-  if (second === null || !second.generic) {
-    return this.TUBE_RADIUS;
-  }
-  var secOpts = this.secCache[second.generic];
-  if (!secOpts) {
-    return this.TUBE_RADIUS;
-  }
-  if (second.term === residue) {
-    return this.ARROW_END;
-  }
-  return secOpts.center;
-};
-
-CartoonMode.prototype.getResidueRadius = function(residue, val) {
-  var startRad = this.getResidueStartRadius(residue);
-  if (val === 0) {
-    return startRad;
-  }
-
-  var endRad = this.getResidueEndRadius(residue);
-  if (val === 2) {
-    return endRad;
-  }
-
-  return startRad.clone().lerp(endRad, val / 2.0);
-};
-
-// TODO: remove when selection is rendered with actual geometry
-CartoonMode.prototype.calcStickRadius = function(_res) {
-  return this.opts.radius;
-};
-
-CartoonMode.prototype.getHeightSegmentsRatio = function() {
-  return this.opts.heightSegmentsRatio;
-};
-
-CartoonMode.prototype.getTension = function() {
-  return this.opts.tension;
-};
-
-CartoonMode.prototype.buildGeometry = function(complex, colorer, mask, material) {
-  var tubeRad = this.opts.radius;
-  var secHeight = this.opts.depth;
-
-  this.TUBE_RADIUS = new THREE.Vector2(tubeRad, tubeRad);
-  this.ARROW_END = new THREE.Vector2(secHeight, tubeRad);
-  var secCache = {};
-  var secData = this.opts.ss;
-  /* eslint-disable guard-for-in */
-  for (var prop in secData) {
-    secCache[prop] = {
-      center: new THREE.Vector2(secHeight, secData[prop].width),
-      start:  new THREE.Vector2(secHeight, secData[prop].arrow)
-    };
-  }
-  this.secCache = secCache;
-  /* eslint-enable guard-for-in */
-
-  return Mode.prototype.buildGeometry.call(this, complex, colorer, mask, material);
-};
+CartoonMode.id = 'CA';
+CartoonMode.prototype.id = 'CA';
+CartoonMode.prototype.name = 'Cartoon';
+CartoonMode.prototype.shortName = 'Cartoon';
+CartoonMode.prototype.depGroups = [
+  'CartoonChains',
+  'NucleicSpheres',
+  'NucleicCylinders',
+];
 
 export default CartoonMode;
 

--- a/src/gfx/modes/CartoonMode.js
+++ b/src/gfx/modes/CartoonMode.js
@@ -11,11 +11,11 @@ class CartoonMode extends Mode {
   }
 
   getResidueStartRadius(residue) {
-    var second = residue.getSecondary();
+    const second = residue.getSecondary();
     if (!second || !second.generic) {
       return this.TUBE_RADIUS;
     }
-    var secOpts = this.secCache[second.generic];
+    const secOpts = this.secCache[second.generic];
     if (!secOpts) {
       return this.TUBE_RADIUS;
     }
@@ -26,11 +26,11 @@ class CartoonMode extends Mode {
   }
 
   getResidueEndRadius(residue) {
-    var second = residue.getSecondary();
+    const second = residue.getSecondary();
     if (second === null || !second.generic) {
       return this.TUBE_RADIUS;
     }
-    var secOpts = this.secCache[second.generic];
+    const secOpts = this.secCache[second.generic];
     if (!secOpts) {
       return this.TUBE_RADIUS;
     }
@@ -41,12 +41,12 @@ class CartoonMode extends Mode {
   }
 
   getResidueRadius(residue, val) {
-    var startRad = this.getResidueStartRadius(residue);
+    const startRad = this.getResidueStartRadius(residue);
     if (val === 0) {
       return startRad;
     }
 
-    var endRad = this.getResidueEndRadius(residue);
+    const endRad = this.getResidueEndRadius(residue);
     if (val === 2) {
       return endRad;
     }
@@ -69,13 +69,13 @@ class CartoonMode extends Mode {
   }
 
   buildGeometry(complex, colorer, mask, material) {
-    var tubeRad = this.opts.radius;
-    var secHeight = this.opts.depth;
+    const tubeRad = this.opts.radius;
+    const secHeight = this.opts.depth;
 
     this.TUBE_RADIUS = new THREE.Vector2(tubeRad, tubeRad);
     this.ARROW_END = new THREE.Vector2(secHeight, tubeRad);
-    var secCache = {};
-    var secData = this.opts.ss;
+    const secCache = {};
+    const secData = this.opts.ss;
     /* eslint-disable guard-for-in */
     for (var prop in secData) {
       secCache[prop] = {

--- a/src/gfx/modes/ContactSurfaceMode.js
+++ b/src/gfx/modes/ContactSurfaceMode.js
@@ -1,8 +1,8 @@
-
-
 import SurfaceMode from './SurfaceMode';
 
 class ContactSurfaceMode extends SurfaceMode {
+  static id = 'CS';
+
   constructor(opts) {
     super(opts);
   }
@@ -21,7 +21,6 @@ class ContactSurfaceMode extends SurfaceMode {
   }
 }
 
-ContactSurfaceMode.id = 'CS';
 ContactSurfaceMode.prototype.id = 'CS';
 ContactSurfaceMode.prototype.name = 'Contact Surface';
 ContactSurfaceMode.prototype.shortName = 'Contact Surf';
@@ -29,4 +28,3 @@ ContactSurfaceMode.prototype.isSurface = true;
 ContactSurfaceMode.prototype.surfaceNames = ['ContactSurfaceGeo'];
 
 export default ContactSurfaceMode;
-

--- a/src/gfx/modes/ContactSurfaceMode.js
+++ b/src/gfx/modes/ContactSurfaceMode.js
@@ -1,34 +1,32 @@
 
 
-import utils from '../../utils';
 import SurfaceMode from './SurfaceMode';
 
-function ContactSurfaceMode(opts) {
-  SurfaceMode.call(this, opts);
+class ContactSurfaceMode extends SurfaceMode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getSurfaceOpts() {
+    return {
+      probeRadius: this.opts.probeRadius,
+      radScale: this.opts.polyComplexity[this.settings.now.resolution],
+      scaleFactor: this.opts.polyComplexity[this.settings.now.resolution], // TODO rename all params
+      gridSpacing: 1.0 / this.opts.polyComplexity[this.settings.now.resolution], // TODO rename all params
+      isoValue: this.opts.isoValue,
+      probePositions: this.opts.probePositions,
+      zClip: this.opts.zClip,
+      visibilitySelector: this.getVisibilitySelector(),
+    };
+  }
 }
 
-utils.deriveClass(ContactSurfaceMode, SurfaceMode, {
-  id: 'CS',
-  name: 'Contact Surface',
-  shortName: 'Contact Surf',
-  isSurface: true,
-  surfaceNames: ['ContactSurfaceGeo'],
-}, {
-  id: 'CS',
-});
-
-ContactSurfaceMode.prototype.getSurfaceOpts = function() {
-  return {
-    probeRadius: this.opts.probeRadius,
-    radScale: this.opts.polyComplexity[this.settings.now.resolution],
-    scaleFactor: this.opts.polyComplexity[this.settings.now.resolution], // TODO rename all params
-    gridSpacing: 1.0 / this.opts.polyComplexity[this.settings.now.resolution], // TODO rename all params
-    isoValue: this.opts.isoValue,
-    probePositions: this.opts.probePositions,
-    zClip: this.opts.zClip,
-    visibilitySelector: this.getVisibilitySelector(),
-  };
-};
+ContactSurfaceMode.id = 'CS';
+ContactSurfaceMode.prototype.id = 'CS';
+ContactSurfaceMode.prototype.name = 'Contact Surface';
+ContactSurfaceMode.prototype.shortName = 'Contact Surf';
+ContactSurfaceMode.prototype.isSurface = true;
+ContactSurfaceMode.prototype.surfaceNames = ['ContactSurfaceGeo'];
 
 export default ContactSurfaceMode;
 

--- a/src/gfx/modes/IsoSurfaceMode.js
+++ b/src/gfx/modes/IsoSurfaceMode.js
@@ -1,43 +1,42 @@
 
 
-import utils from '../../utils';
 import SurfaceMode from './SurfaceMode';
 
-function IsoSurfaceMode(excludeProbe, opts) {
-  SurfaceMode.call(this, opts);
-  this._excludeProbe = excludeProbe;
+class IsoSurfaceMode extends SurfaceMode {
+  constructor(excludeProbe, opts) {
+    super(opts);
+    this._excludeProbe = excludeProbe;
+
+    //this._isVertexNormalsRendered = false; FIXME are used?
+    //this._isSurfaceTransparent = false; FIXME are used?
+  }
+
+  calcAtomRadius(atom) {
+    return atom.element.radius;
+  }
+
+  getSurfaceOpts() {
+    return {
+      gridSpacing: this.opts.polyComplexity[this.settings.now.resolution],
+      radScale: this._radScale,
+      zClip: this.opts.zClip,
+      visibilitySelector: this.getVisibilitySelector(),
+      probeRadius: this.opts.probeRadius,
+      excludeProbe: this._excludeProbe,
+      clusterizationType: this._clusterViaKMeans,
+    };
+  }
 }
 
-utils.deriveClass(IsoSurfaceMode, SurfaceMode, {
-  id: 'SU',
-  name: 'Surface',
-  shortName: 'Surface',
-  surfaceNames: ['SASSESSurfaceGeo'],
-});
+IsoSurfaceMode.prototype.id = 'SU';
+IsoSurfaceMode.prototype.name = 'Surface';
+IsoSurfaceMode.prototype.shortName = 'Surface';
+IsoSurfaceMode.prototype.surfaceNames = ['SASSESSurfaceGeo'];
 
 IsoSurfaceMode.prototype._radScale = 1;
-IsoSurfaceMode.prototype._isVertexNormalsRendered = false;
-IsoSurfaceMode.prototype._isSurfaceTransparent = false;
-
 // TODO: move to advanced visualization UI next 3 params
 IsoSurfaceMode.prototype._clusterViaKMeans = 0; // 0: no cluster, 1: KMeans, 2: SimplestClusterization
 IsoSurfaceMode.prototype._excludeProbe = false;
-
-IsoSurfaceMode.prototype.calcAtomRadius = function(atom) {
-  return atom.element.radius;
-};
-
-IsoSurfaceMode.prototype.getSurfaceOpts = function() {
-  return {
-    gridSpacing: this.opts.polyComplexity[this.settings.now.resolution],
-    radScale: this._radScale,
-    zClip: this.opts.zClip,
-    visibilitySelector: this.getVisibilitySelector(),
-    probeRadius: this.opts.probeRadius,
-    excludeProbe: this._excludeProbe,
-    clusterizationType: this._clusterViaKMeans,
-  };
-};
 
 export default IsoSurfaceMode;
 

--- a/src/gfx/modes/IsoSurfaceMode.js
+++ b/src/gfx/modes/IsoSurfaceMode.js
@@ -1,5 +1,3 @@
-
-
 import SurfaceMode from './SurfaceMode';
 
 class IsoSurfaceMode extends SurfaceMode {
@@ -39,4 +37,3 @@ IsoSurfaceMode.prototype._clusterViaKMeans = 0; // 0: no cluster, 1: KMeans, 2: 
 IsoSurfaceMode.prototype._excludeProbe = false;
 
 export default IsoSurfaceMode;
-

--- a/src/gfx/modes/IsoSurfaceSASMode.js
+++ b/src/gfx/modes/IsoSurfaceSASMode.js
@@ -1,17 +1,15 @@
-
-
 import IsoSurfaceMode from './IsoSurfaceMode';
 
 class IsoSurfaceSASMode extends IsoSurfaceMode {
+  static id = 'SA';
+
   constructor(opts) {
     super(false, opts);
   }
 }
 
-IsoSurfaceSASMode.id = 'SA';
 IsoSurfaceSASMode.prototype.id = 'SA';
 IsoSurfaceSASMode.prototype.name = 'Solvent Accessible Surface';
 IsoSurfaceSASMode.prototype.shortName = 'SAS';
 
 export default IsoSurfaceSASMode;
-

--- a/src/gfx/modes/IsoSurfaceSASMode.js
+++ b/src/gfx/modes/IsoSurfaceSASMode.js
@@ -1,19 +1,17 @@
 
 
-import utils from '../../utils';
 import IsoSurfaceMode from './IsoSurfaceMode';
 
-function IsoSurfaceSASMode(opts) {
-  IsoSurfaceMode.call(this, false, opts);
+class IsoSurfaceSASMode extends IsoSurfaceMode {
+  constructor(opts) {
+    super(false, opts);
+  }
 }
 
-utils.deriveClass(IsoSurfaceSASMode, IsoSurfaceMode, {
-  id: 'SA',
-  name: 'Solvent Accessible Surface',
-  shortName: 'SAS',
-}, {
-  id: 'SA',
-});
+IsoSurfaceSASMode.id = 'SA';
+IsoSurfaceSASMode.prototype.id = 'SA';
+IsoSurfaceSASMode.prototype.name = 'Solvent Accessible Surface';
+IsoSurfaceSASMode.prototype.shortName = 'SAS';
 
 export default IsoSurfaceSASMode;
 

--- a/src/gfx/modes/IsoSurfaceSESMode.js
+++ b/src/gfx/modes/IsoSurfaceSESMode.js
@@ -1,17 +1,15 @@
-
-
 import IsoSurfaceMode from './IsoSurfaceMode';
 
 class IsoSurfaceSESMode extends IsoSurfaceMode {
+  static id = 'SE';
+
   constructor(opts) {
     super(true, opts);
   }
 }
 
-IsoSurfaceSESMode.id = 'SE';
 IsoSurfaceSESMode.prototype.id = 'SE';
 IsoSurfaceSESMode.prototype.name = 'Solvent Excluded Surface';
 IsoSurfaceSESMode.prototype.shortName = 'SES';
 
 export default IsoSurfaceSESMode;
-

--- a/src/gfx/modes/IsoSurfaceSESMode.js
+++ b/src/gfx/modes/IsoSurfaceSESMode.js
@@ -1,19 +1,17 @@
 
 
-import utils from '../../utils';
 import IsoSurfaceMode from './IsoSurfaceMode';
 
-function IsoSurfaceSESMode(opts) {
-  IsoSurfaceMode.call(this, true, opts);
+class IsoSurfaceSESMode extends IsoSurfaceMode {
+  constructor(opts) {
+    super(true, opts);
+  }
 }
 
-utils.deriveClass(IsoSurfaceSESMode, IsoSurfaceMode, {
-  id: 'SE',
-  name: 'Solvent Excluded Surface',
-  shortName: 'SES',
-}, {
-  id: 'SE',
-});
+IsoSurfaceSESMode.id = 'SE';
+IsoSurfaceSESMode.prototype.id = 'SE';
+IsoSurfaceSESMode.prototype.name = 'Solvent Excluded Surface';
+IsoSurfaceSESMode.prototype.shortName = 'SES';
 
 export default IsoSurfaceSESMode;
 

--- a/src/gfx/modes/LabeledMode.js
+++ b/src/gfx/modes/LabeledMode.js
@@ -4,29 +4,28 @@
 import Mode from './Mode';
 
 /** @deprecated Old-fashioned atom labels, to be removed in the next major version. */
-function LabeledMode(opts) {
-  Mode.call(this, opts);
-  this.depGroups = this.depGroups.slice(0); // clone depGroups to prevent prototype edits
-  this._staticGroups = this.depGroups.length;
-}
-
-LabeledMode.prototype = Object.create(Mode.prototype);
-LabeledMode.prototype.constructor = LabeledMode;
-
-LabeledMode.prototype.update = function() {
-  var statGroups = this._staticGroups;
-  if (this.settings.now.labels === 'no') {
-    this.depGroups = this.depGroups.slice(0, statGroups);
-  } else {
-    this.depGroups[statGroups] = 'TextLabelsGeo';
-    this.depGroups[statGroups + 1] = 'SGroupsLabels';
+class LabeledMode extends Mode {
+  constructor(opts) {
+    super(opts);
+    this.depGroups = this.depGroups.slice(0); // clone depGroups to prevent prototype edits
+    this._staticGroups = this.depGroups.length;
   }
-};
 
-LabeledMode.prototype.buildGeometry = function(complex, colorer, mask, material) {
-  this.update();
-  return  Mode.prototype.buildGeometry.call(this, complex, colorer, mask, material);
-};
+  update() {
+    var statGroups = this._staticGroups;
+    if (this.settings.now.labels === 'no') {
+      this.depGroups = this.depGroups.slice(0, statGroups);
+    } else {
+      this.depGroups[statGroups] = 'TextLabelsGeo';
+      this.depGroups[statGroups + 1] = 'SGroupsLabels';
+    }
+  }
+
+  buildGeometry(complex, colorer, mask, material) {
+    this.update();
+    return Mode.prototype.buildGeometry.call(this, complex, colorer, mask, material);
+  }
+}
 
 export default LabeledMode;
 

--- a/src/gfx/modes/LabeledMode.js
+++ b/src/gfx/modes/LabeledMode.js
@@ -1,5 +1,3 @@
-
-
 /* eslint-disable no-magic-numbers */
 import Mode from './Mode';
 
@@ -28,4 +26,3 @@ class LabeledMode extends Mode {
 }
 
 export default LabeledMode;
-

--- a/src/gfx/modes/LabeledMode.js
+++ b/src/gfx/modes/LabeledMode.js
@@ -12,7 +12,7 @@ class LabeledMode extends Mode {
   }
 
   update() {
-    var statGroups = this._staticGroups;
+    const statGroups = this._staticGroups;
     if (this.settings.now.labels === 'no') {
       this.depGroups = this.depGroups.slice(0, statGroups);
     } else {

--- a/src/gfx/modes/LicoriceMode.js
+++ b/src/gfx/modes/LicoriceMode.js
@@ -1,61 +1,60 @@
 
 
 /* eslint-disable no-magic-numbers */
-import utils from '../../utils';
 import LabeledMode from './LabeledMode';
-function LicoriceMode(opts) {
-  LabeledMode.call(this, opts);
+class LicoriceMode extends LabeledMode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  calcAtomRadius(_atom) {
+    return this.opts.bond;
+  }
+
+  calcStickRadius() {
+    return this.opts.bond;
+  }
+
+  calcSpaceFraction() {
+    return this.opts.space;
+  }
+
+  getAromRadius() {
+    return this.opts.aromrad;
+  }
+
+  showAromaticLoops() {
+    return this.opts.showarom;
+  }
+
+  drawMultiorderBonds() {
+    return this.opts.multibond;
+  }
+
+  /** @deprecated Old-fashioned atom labels, to be removed in the next major version. */
+
+  getLabelOpts() {
+    return {
+      fg: 'none',
+      bg: '0x202020',
+      showBg: false,
+      labels: this.settings.now.labels,
+      colors: true,
+      adjustColor: true,
+      transparent: true,
+    };
+  }
 }
 
-utils.deriveClass(LicoriceMode, LabeledMode, {
-  id: 'LC',
-  name: 'Licorice',
-  shortName: 'Licorice',
-  depGroups: [
-    'AtomsSpheres',
-    'BondsCylinders',
-    'ALoopsTorus',
-  ],
-}, {
-  id: 'LC',
-});
-
-LicoriceMode.prototype.calcAtomRadius = function(_atom) {
-  return this.opts.bond;
-};
-
-LicoriceMode.prototype.calcStickRadius = function() {
-  return this.opts.bond;
-};
-
-LicoriceMode.prototype.calcSpaceFraction = function() {
-  return this.opts.space;
-};
-
-LicoriceMode.prototype.getAromRadius = function() {
-  return this.opts.aromrad;
-};
-
-LicoriceMode.prototype.showAromaticLoops = function() {
-  return this.opts.showarom;
-};
-
-LicoriceMode.prototype.drawMultiorderBonds = function() {
-  return this.opts.multibond;
-};
-
-/** @deprecated Old-fashioned atom labels, to be removed in the next major version. */
-LicoriceMode.prototype.getLabelOpts = function() {
-  return {
-    fg: 'none',
-    bg: '0x202020',
-    showBg: false,
-    labels: this.settings.now.labels,
-    colors: true,
-    adjustColor: true,
-    transparent: true,
-  };
-};
+LicoriceMode.id = 'LC';
+LicoriceMode.prototype.id = 'LC';
+LicoriceMode.prototype.hortName = 'Licorice';
+LicoriceMode.prototype.shortName = 'Licorice';
+LicoriceMode.prototype.depGroups = [
+  'AtomsSpheres',
+  'BondsCylinders',
+  'ALoopsTorus',
+];
 
 export default LicoriceMode;
 

--- a/src/gfx/modes/LicoriceMode.js
+++ b/src/gfx/modes/LicoriceMode.js
@@ -1,8 +1,8 @@
-
-
 /* eslint-disable no-magic-numbers */
 import LabeledMode from './LabeledMode';
 class LicoriceMode extends LabeledMode {
+  static id = 'LC';
+
   constructor(opts) {
     super(opts);
   }
@@ -46,7 +46,6 @@ class LicoriceMode extends LabeledMode {
   }
 }
 
-LicoriceMode.id = 'LC';
 LicoriceMode.prototype.id = 'LC';
 LicoriceMode.prototype.hortName = 'Licorice';
 LicoriceMode.prototype.shortName = 'Licorice';
@@ -57,4 +56,3 @@ LicoriceMode.prototype.depGroups = [
 ];
 
 export default LicoriceMode;
-

--- a/src/gfx/modes/LinesMode.js
+++ b/src/gfx/modes/LinesMode.js
@@ -1,5 +1,3 @@
-
-
 import LabeledMode from './LabeledMode';
 
 function getRenderParams() {
@@ -9,6 +7,8 @@ function getRenderParams() {
 }
 
 class LinesMode extends LabeledMode {
+  static id = 'LN';
+
   constructor(opts) {
     super(opts);
     const groups = this.depGroups;
@@ -52,7 +52,6 @@ class LinesMode extends LabeledMode {
   }
 }
 
-LinesMode.id = 'LN';
 LinesMode.prototype.id = 'LN';
 LinesMode.prototype.name = 'Lines';
 LinesMode.prototype.shortName = 'Lines';
@@ -63,4 +62,3 @@ LinesMode.prototype.depGroups = [
 ];
 
 export default LinesMode;
-

--- a/src/gfx/modes/LinesMode.js
+++ b/src/gfx/modes/LinesMode.js
@@ -1,6 +1,5 @@
 
 
-import utils from '../../utils';
 import LabeledMode from './LabeledMode';
 
 function getRenderParams() {
@@ -9,59 +8,59 @@ function getRenderParams() {
   };
 }
 
-function LinesMode(opts) {
-  LabeledMode.call(this, opts);
-  var groups = this.depGroups;
-  for (var i = 0, n = groups.length; i < n; ++i) {
-    groups[i] = [groups[i], getRenderParams];
+class LinesMode extends LabeledMode {
+  constructor(opts) {
+    super(opts);
+    var groups = this.depGroups;
+    for (var i = 0, n = groups.length; i < n; ++i) {
+      groups[i] = [groups[i], getRenderParams];
+    }
+  }
+
+  drawMultiorderBonds() {
+    return this.opts.multibond;
+  }
+
+  calcAtomRadius() {
+    return this.opts.atom;
+  }
+
+  getAromaticOffset() {
+    return this.opts.offsarom;
+  }
+
+  getAromaticArcChunks() {
+    return this.opts.chunkarom;
+  }
+
+  showAromaticLoops() {
+    return this.opts.showarom;
+  }
+
+  /** @deprecated Old-fashioned atom labels, to be removed in the next major version. */
+
+  getLabelOpts() {
+    return {
+      fg: 'none',
+      bg: '0x202020',
+      showBg: true,
+      labels: this.settings.now.labels,
+      colors: true,
+      adjustColor: true,
+      transparent: true,
+    };
   }
 }
 
-utils.deriveClass(LinesMode, LabeledMode, {
-  id: 'LN',
-  name: 'Lines',
-  shortName: 'Lines',
-  depGroups: [
-    'ALoopsLines',
-    'BondsLines',
-    'OrphanedAtomsCrosses',
-  ],
-}, {
-  id: 'LN',
-});
-
-LinesMode.prototype.drawMultiorderBonds = function() {
-  return this.opts.multibond;
-};
-
-LinesMode.prototype.calcAtomRadius = function() {
-  return this.opts.atom;
-};
-
-LinesMode.prototype.getAromaticOffset = function() {
-  return this.opts.offsarom;
-};
-
-LinesMode.prototype.getAromaticArcChunks = function() {
-  return this.opts.chunkarom;
-};
-
-LinesMode.prototype.showAromaticLoops = function() {
-  return this.opts.showarom;
-};
-
-/** @deprecated Old-fashioned atom labels, to be removed in the next major version. */
-LinesMode.prototype.getLabelOpts = function() {
-  return {
-    fg: 'none',
-    bg: '0x202020',
-    showBg: true,
-    labels: this.settings.now.labels,
-    colors: true,
-    adjustColor: true,
-    transparent: true,
-  };
-};
+LinesMode.id = 'LN';
+LinesMode.prototype.id = 'LN';
+LinesMode.prototype.name = 'Lines';
+LinesMode.prototype.shortName = 'Lines';
+LinesMode.prototype.depGroups = [
+  'ALoopsLines',
+  'BondsLines',
+  'OrphanedAtomsCrosses',
+];
 
 export default LinesMode;
 

--- a/src/gfx/modes/LinesMode.js
+++ b/src/gfx/modes/LinesMode.js
@@ -11,8 +11,8 @@ function getRenderParams() {
 class LinesMode extends LabeledMode {
   constructor(opts) {
     super(opts);
-    var groups = this.depGroups;
-    for (var i = 0, n = groups.length; i < n; ++i) {
+    const groups = this.depGroups;
+    for (let i = 0, n = groups.length; i < n; ++i) {
       groups[i] = [groups[i], getRenderParams];
     }
   }

--- a/src/gfx/modes/Mode.js
+++ b/src/gfx/modes/Mode.js
@@ -1,5 +1,3 @@
-
-
 import _ from 'lodash';
 import makeContextDependent from '../../utils/makeContextDependent';
 import utils from '../../utils';
@@ -85,4 +83,3 @@ Mode.prototype.id = '__';
 Mode.prototype.depGroups = [];
 
 export default Mode;
-

--- a/src/gfx/modes/Mode.js
+++ b/src/gfx/modes/Mode.js
@@ -40,7 +40,7 @@ class Mode {
    * Options are returned if they were changed during or after the mode creation.
    */
   identify() {
-    var diff = utils.objectsDiff(this.opts, this.settings.now.modes[this.id]);
+    const diff = utils.objectsDiff(this.opts, this.settings.now.modes[this.id]);
     if (!_.isEmpty(diff)) {
       return [this.id, diff];
     }
@@ -48,20 +48,20 @@ class Mode {
   }
 
   buildGeometry(complex, colorer, mask, material) {
-    var polyComplexity = this.opts.polyComplexity ? this.opts.polyComplexity[this.settings.now.resolution] : 0;
-    var groupList = this.depGroups;
-    var groupCount = groupList.length;
-    var group = new gfxutils.RCGroup();
-    var self = this;
-    for (var i = 0; i < groupCount; ++i) {
-      var currGroup = groupList[i];
-      var renderParams = {};
+    const polyComplexity = this.opts.polyComplexity ? this.opts.polyComplexity[this.settings.now.resolution] : 0;
+    const groupList = this.depGroups;
+    const groupCount = groupList.length;
+    const group = new gfxutils.RCGroup();
+    const self = this;
+    for (let i = 0; i < groupCount; ++i) {
+      let currGroup = groupList[i];
+      let renderParams = {};
       if (_.isArray(currGroup)) {
         renderParams = currGroup[1].call(this);
         currGroup = currGroup[0];
       }
-      var Group = factory[currGroup](null, this.settings, renderParams);
-      var newGroup = new Group(complex, colorer, self, polyComplexity, mask, material);
+      const Group = factory[currGroup](null, this.settings, renderParams);
+      const newGroup = new Group(complex, colorer, self, polyComplexity, mask, material);
       if (newGroup.children.length > 0) {
         group.add(newGroup);
       }

--- a/src/gfx/modes/QuickSurfaceMode.js
+++ b/src/gfx/modes/QuickSurfaceMode.js
@@ -1,32 +1,30 @@
 
 
-import utils from '../../utils';
 import SurfaceMode from './SurfaceMode';
 
-function QuickSurfaceMode(opts) {
-  SurfaceMode.call(this, opts);
+class QuickSurfaceMode extends SurfaceMode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getSurfaceOpts() {
+    return {
+      useBeads: false,
+      isoValue: this.opts.isoValue,
+      gaussLim: this.opts.gaussLim[this.settings.now.resolution],
+      radScale: this.opts.scale,
+      gridSpacing: this.opts.gridSpacing[this.settings.now.resolution],
+      zClip: this.opts.zClip,
+      visibilitySelector: this.getVisibilitySelector(),
+    };
+  }
 }
 
-utils.deriveClass(QuickSurfaceMode, SurfaceMode, {
-  id: 'QS',
-  name: 'Quick Surface',
-  shortName: 'Quick Surf',
-  surfaceNames: ['QuickSurfGeo'],
-}, {
-  id: 'QS',
-});
-
-QuickSurfaceMode.prototype.getSurfaceOpts = function() {
-  return {
-    useBeads: false,
-    isoValue: this.opts.isoValue,
-    gaussLim: this.opts.gaussLim[this.settings.now.resolution],
-    radScale: this.opts.scale,
-    gridSpacing: this.opts.gridSpacing[this.settings.now.resolution],
-    zClip: this.opts.zClip,
-    visibilitySelector: this.getVisibilitySelector(),
-  };
-};
+QuickSurfaceMode.id = 'QS';
+QuickSurfaceMode.prototype.id = 'QS';
+QuickSurfaceMode.prototype.name = 'Quick Surface';
+QuickSurfaceMode.prototype.shortName = 'Quick Surf';
+QuickSurfaceMode.prototype.surfaceNames = ['QuickSurfGeo'];
 
 export default QuickSurfaceMode;
 

--- a/src/gfx/modes/QuickSurfaceMode.js
+++ b/src/gfx/modes/QuickSurfaceMode.js
@@ -1,8 +1,8 @@
-
-
 import SurfaceMode from './SurfaceMode';
 
 class QuickSurfaceMode extends SurfaceMode {
+  static id = 'QS';
+
   constructor(opts) {
     super(opts);
   }
@@ -20,11 +20,9 @@ class QuickSurfaceMode extends SurfaceMode {
   }
 }
 
-QuickSurfaceMode.id = 'QS';
 QuickSurfaceMode.prototype.id = 'QS';
 QuickSurfaceMode.prototype.name = 'Quick Surface';
 QuickSurfaceMode.prototype.shortName = 'Quick Surf';
 QuickSurfaceMode.prototype.surfaceNames = ['QuickSurfGeo'];
 
 export default QuickSurfaceMode;
-

--- a/src/gfx/modes/SurfaceMode.js
+++ b/src/gfx/modes/SurfaceMode.js
@@ -3,7 +3,7 @@
 import chem from '../../chem';
 import Mode from './Mode';
 
-var selectors = chem.selectors;
+const selectors = chem.selectors;
 
 function getRenderParams() {
   return {
@@ -16,9 +16,9 @@ class SurfaceMode extends Mode {
   constructor(opts) {
     super(opts);
     this.depGroups = this.depGroups.slice(0); // clone depGroups to prevent prototype edits
-    var surfaces = this.surfaceNames;
-    var groups = this.depGroups;
-    for (var i = 0, n = surfaces.length; i < n; ++i) {
+    const surfaces = this.surfaceNames;
+    const groups = this.depGroups;
+    for (let i = 0, n = surfaces.length; i < n; ++i) {
       groups[groups.length] = [surfaces[i], getRenderParams];
     }
   }
@@ -28,9 +28,9 @@ class SurfaceMode extends Mode {
   }
 
   getVisibilitySelector() {
-    var visibilitySelector = null;
+    let visibilitySelector = null;
     if (this.opts.subset !== '') {
-      var res = selectors.parse(this.opts.subset);
+      const res = selectors.parse(this.opts.subset);
       if (!res.error) {
         visibilitySelector = res.selector;
       }

--- a/src/gfx/modes/SurfaceMode.js
+++ b/src/gfx/modes/SurfaceMode.js
@@ -1,7 +1,6 @@
 
 
 import chem from '../../chem';
-import utils from '../../utils';
 import Mode from './Mode';
 
 var selectors = chem.selectors;
@@ -13,35 +12,35 @@ function getRenderParams() {
   };
 }
 
-function SurfaceMode(opts) {
-  Mode.call(this, opts);
-  this.depGroups = this.depGroups.slice(0); // clone depGroups to prevent prototype edits
-  var surfaces = this.surfaceNames;
-  var groups = this.depGroups;
-  for (var i = 0, n = surfaces.length; i < n; ++i) {
-    groups[groups.length] = [surfaces[i], getRenderParams];
+class SurfaceMode extends Mode {
+  constructor(opts) {
+    super(opts);
+    this.depGroups = this.depGroups.slice(0); // clone depGroups to prevent prototype edits
+    var surfaces = this.surfaceNames;
+    var groups = this.depGroups;
+    for (var i = 0, n = surfaces.length; i < n; ++i) {
+      groups[groups.length] = [surfaces[i], getRenderParams];
+    }
+  }
+
+  calcAtomRadius(atom) {
+    return atom.element.radius;
+  }
+
+  getVisibilitySelector() {
+    var visibilitySelector = null;
+    if (this.opts.subset !== '') {
+      var res = selectors.parse(this.opts.subset);
+      if (!res.error) {
+        visibilitySelector = res.selector;
+      }
+    }
+    return visibilitySelector;
   }
 }
 
-utils.deriveClass(SurfaceMode, Mode, {
-  isSurface: true,
-  surfaceNames: [],
-});
-
-SurfaceMode.prototype.calcAtomRadius = function(atom) {
-  return atom.element.radius;
-};
-
-SurfaceMode.prototype.getVisibilitySelector = function() {
-  var visibilitySelector = null;
-  if (this.opts.subset !== '') {
-    var res = selectors.parse(this.opts.subset);
-    if (!res.error) {
-      visibilitySelector = res.selector;
-    }
-  }
-  return visibilitySelector;
-};
+SurfaceMode.prototype.isSurface = true;
+SurfaceMode.prototype.surfaceNames = [];
 
 export default SurfaceMode;
 

--- a/src/gfx/modes/SurfaceMode.js
+++ b/src/gfx/modes/SurfaceMode.js
@@ -1,5 +1,3 @@
-
-
 import chem from '../../chem';
 import Mode from './Mode';
 
@@ -43,4 +41,3 @@ SurfaceMode.prototype.isSurface = true;
 SurfaceMode.prototype.surfaceNames = [];
 
 export default SurfaceMode;
-

--- a/src/gfx/modes/TextMode.js
+++ b/src/gfx/modes/TextMode.js
@@ -1,9 +1,9 @@
-
-
 import _ from 'lodash';
 import Mode from './Mode';
 
 class TextMode extends Mode {
+  static id = 'TX';
+
   constructor(opts) {
     super(opts);
   }
@@ -22,11 +22,9 @@ class TextMode extends Mode {
   }
 }
 
-TextMode.id = 'TX';
 TextMode.prototype.id = 'TX';
 TextMode.prototype.name = 'Text mode';
 TextMode.prototype.shortName = 'Text';
 TextMode.prototype.depGroups = ['TextLabelsGeo'];
 
 export default TextMode;
-

--- a/src/gfx/modes/TextMode.js
+++ b/src/gfx/modes/TextMode.js
@@ -1,32 +1,32 @@
+
+
 import _ from 'lodash';
-import utils from '../../utils';
 import Mode from './Mode';
 
-function TextMode(opts) {
-  Mode.call(this, opts);
+class TextMode extends Mode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getTemplateOptions() {
+    return this.opts.template;
+  }
+
+  getLabelOpts() {
+    return _.merge(this.opts, {
+      labels: this.settings.now.labels,
+      colors: true,
+      adjustColor: true,
+      transparent: true,
+    });
+  }
 }
 
-utils.deriveClass(TextMode, Mode, {
-  id: 'TX',
-  name: 'Text mode',
-  shortName: 'Text',
-  depGroups: ['TextLabelsGeo']
-}, {
-  id: 'TX',
-});
-
-TextMode.prototype.getTemplateOptions = function() {
-  return this.opts.template;
-};
-
-TextMode.prototype.getLabelOpts = function() {
-  return _.merge(this.opts, {
-    labels: this.settings.now.labels,
-    colors: true,
-    adjustColor: true,
-    transparent: true,
-  });
-};
+TextMode.id = 'TX';
+TextMode.prototype.id = 'TX';
+TextMode.prototype.name = 'Text mode';
+TextMode.prototype.shortName = 'Text';
+TextMode.prototype.depGroups = ['TextLabelsGeo'];
 
 export default TextMode;
 

--- a/src/gfx/modes/TraceMode.js
+++ b/src/gfx/modes/TraceMode.js
@@ -1,24 +1,22 @@
 
 
-import utils from '../../utils';
 import Mode from './Mode';
 
-function TraceMode(opts) {
-  Mode.call(this, opts);
+class TraceMode extends Mode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  calcStickRadius() {
+    return this.opts.radius;
+  }
 }
 
-utils.deriveClass(TraceMode, Mode, {
-  id: 'TR',
-  name: 'Trace',
-  shortName: 'Trace',
-  depGroups: ['TraceChains'],
-}, {
-  id: 'TR',
-});
-
-TraceMode.prototype.calcStickRadius = function() {
-  return this.opts.radius;
-};
+TraceMode.id = 'TR';
+TraceMode.prototype.id = 'TR';
+TraceMode.prototype.name = 'Trace';
+TraceMode.prototype.shortName = 'Trace';
+TraceMode.prototype.depGroups = ['TraceChains'];
 
 export default TraceMode;
 

--- a/src/gfx/modes/TraceMode.js
+++ b/src/gfx/modes/TraceMode.js
@@ -1,8 +1,8 @@
-
-
 import Mode from './Mode';
 
 class TraceMode extends Mode {
+  static id = 'TR';
+
   constructor(opts) {
     super(opts);
   }
@@ -12,11 +12,9 @@ class TraceMode extends Mode {
   }
 }
 
-TraceMode.id = 'TR';
 TraceMode.prototype.id = 'TR';
 TraceMode.prototype.name = 'Trace';
 TraceMode.prototype.shortName = 'Trace';
 TraceMode.prototype.depGroups = ['TraceChains'];
 
 export default TraceMode;
-

--- a/src/gfx/modes/TubeMode.js
+++ b/src/gfx/modes/TubeMode.js
@@ -1,9 +1,9 @@
-
-
 import * as THREE from 'three';
 import Mode from './Mode';
 
 class TubeMode extends Mode {
+  static id = 'TU';
+
   constructor(opts) {
     super(opts);
   }
@@ -28,11 +28,9 @@ class TubeMode extends Mode {
   }
 }
 
-TubeMode.id = 'TU';
 TubeMode.prototype.id = 'TU';
 TubeMode.prototype.name = 'Tube';
 TubeMode.prototype.shortName = 'Tube';
 TubeMode.prototype.depGroups = ['CartoonChains'];
 
 export default TubeMode;
-

--- a/src/gfx/modes/TubeMode.js
+++ b/src/gfx/modes/TubeMode.js
@@ -21,7 +21,7 @@ class TubeMode extends Mode {
   }
 
   buildGeometry(complex, colorer, mask, material) {
-    var rad = this.opts.radius;
+    const rad = this.opts.radius;
     this.TUBE_RADIUS = new THREE.Vector2(rad, rad);
 
     return Mode.prototype.buildGeometry.call(this, complex, colorer, mask, material);

--- a/src/gfx/modes/TubeMode.js
+++ b/src/gfx/modes/TubeMode.js
@@ -1,40 +1,38 @@
 
 
 import * as THREE from 'three';
-import utils from '../../utils';
 import Mode from './Mode';
 
-function TubeMode(opts) {
-  Mode.call(this, opts);
+class TubeMode extends Mode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  getResidueRadius(_residue) {
+    return this.TUBE_RADIUS;
+  }
+
+  getHeightSegmentsRatio() {
+    return this.opts.heightSegmentsRatio;
+  }
+
+  getTension() {
+    return this.opts.tension;
+  }
+
+  buildGeometry(complex, colorer, mask, material) {
+    var rad = this.opts.radius;
+    this.TUBE_RADIUS = new THREE.Vector2(rad, rad);
+
+    return Mode.prototype.buildGeometry.call(this, complex, colorer, mask, material);
+  }
 }
 
-utils.deriveClass(TubeMode, Mode, {
-  id: 'TU',
-  name: 'Tube',
-  shortName: 'Tube',
-  depGroups: ['CartoonChains'],
-}, {
-  id: 'TU',
-});
-
-TubeMode.prototype.getResidueRadius = function(_residue) {
-  return this.TUBE_RADIUS;
-};
-
-TubeMode.prototype.getHeightSegmentsRatio = function() {
-  return this.opts.heightSegmentsRatio;
-};
-
-TubeMode.prototype.getTension = function() {
-  return this.opts.tension;
-};
-
-TubeMode.prototype.buildGeometry = function(complex, colorer, mask, material) {
-  var rad = this.opts.radius;
-  this.TUBE_RADIUS = new THREE.Vector2(rad, rad);
-
-  return Mode.prototype.buildGeometry.call(this, complex, colorer, mask, material);
-};
+TubeMode.id = 'TU';
+TubeMode.prototype.id = 'TU';
+TubeMode.prototype.name = 'Tube';
+TubeMode.prototype.shortName = 'Tube';
+TubeMode.prototype.depGroups = ['CartoonChains'];
 
 export default TubeMode;
 

--- a/src/gfx/modes/VanDerWaalsMode.js
+++ b/src/gfx/modes/VanDerWaalsMode.js
@@ -1,8 +1,8 @@
-
-
 import Mode from './Mode';
 
 class VanDerWaalsMode extends Mode {
+  static id = 'VW';
+
   constructor(opts) {
     super(opts);
   }
@@ -12,11 +12,9 @@ class VanDerWaalsMode extends Mode {
   }
 }
 
-VanDerWaalsMode.id = 'VW';
 VanDerWaalsMode.prototype.id = 'VW';
 VanDerWaalsMode.prototype.name = 'Van der Waals';
 VanDerWaalsMode.prototype.shortName = 'VDW';
 VanDerWaalsMode.prototype.depGroups = ['AtomsSpheres'];
 
 export default VanDerWaalsMode;
-

--- a/src/gfx/modes/VanDerWaalsMode.js
+++ b/src/gfx/modes/VanDerWaalsMode.js
@@ -1,24 +1,22 @@
 
 
-import utils from '../../utils';
 import Mode from './Mode';
 
-function VanDerWaalsMode(opts) {
-  Mode.call(this, opts);
+class VanDerWaalsMode extends Mode {
+  constructor(opts) {
+    super(opts);
+  }
+
+  calcAtomRadius(atom) {
+    return atom.element.radius;
+  }
 }
 
-utils.deriveClass(VanDerWaalsMode, Mode, {
-  id: 'VW',
-  name: 'Van der Waals',
-  shortName: 'VDW',
-  depGroups: ['AtomsSpheres'],
-}, {
-  id: 'VW',
-});
-
-VanDerWaalsMode.prototype.calcAtomRadius = function(atom) {
-  return atom.element.radius;
-};
+VanDerWaalsMode.id = 'VW';
+VanDerWaalsMode.prototype.id = 'VW';
+VanDerWaalsMode.prototype.name = 'Van der Waals';
+VanDerWaalsMode.prototype.shortName = 'VDW';
+VanDerWaalsMode.prototype.depGroups = ['AtomsSpheres'];
 
 export default VanDerWaalsMode;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,6 +661,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
@@ -684,6 +688,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
## Description
Classes were created, added usage let/const instead of var.

## Motivation and Context
Code base supports old standard of JS, standard was changed to ES2015.

## How Has This Been Tested?
Tests e2e weren't passed because of different size of screenshots.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
