### PR TITLE
Fix fog interpolation for sprites

### DIFF
--- a/src/gfx/shaders/Uber_frag.glsl
+++ b/src/gfx/shaders/Uber_frag.glsl
@@ -439,7 +439,13 @@ void main() {
   #endif
 
   #ifdef USE_FOG
-    float fogFactor = smoothstep( fogNear, fogFar, vViewPosition.z );
+    float viewDistance;
+    #if defined(SPHERE_SPRITE) || defined(CYLINDER_SPRITE)
+      viewDistance = abs(pixelPosEye.z);
+    #else
+      viewDistance = vViewPosition.z;
+    #endif
+    float fogFactor = smoothstep( fogNear, fogFar, viewDistance);
     #ifdef FOG_TRANSPARENT
       gl_FragColor.a = gl_FragColor.a * (1.0 - fogFactor);
     #else


### PR DESCRIPTION
## Description
Correct the color of sprites for flat material in the fog.

## How Has This Been Tested?
Has been tested by npm run ci test

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
