### PR TITLE
Add fogAlpha

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -3136,6 +3136,14 @@ Miew.prototype._fogFarUpdateValue = function() {
   }
 };
 
+Miew.prototype._fogAlphaChanged = function() {
+  this._forEachComplexVisual(function(visual) {
+    visual.setUberOptions({
+      fogAlpha: settings.now.fogAlpha
+    });
+  });
+};
+
 Miew.prototype._initOnSettingsChanged = function() {
   const on = (props, func) => {
     props = _.isArray(props) ? props : [props];
@@ -3199,6 +3207,10 @@ Miew.prototype._initOnSettingsChanged = function() {
 
   on(['fog', 'fogNearFactor', 'fogFarFactor'], () => {
     this._updateFog();
+  });
+
+  on('fogAlpha', () => {
+    this._fogAlphaChanged();
   });
 
   on('autoResolution', (evt) => {

--- a/src/gfx/Representation.js
+++ b/src/gfx/Representation.js
@@ -15,6 +15,7 @@ function Representation(index, mode, colorer, selector) {
   this.count = 0;
   this.material = new UberMaterial();
   this.material.setValues({clipPlane: settings.now.draft.clipPlane, fogTransparent: settings.now.bg.transparent});
+  this.material.setUberOptions({fogAlpha: settings.now.fogAlpha});
   this.materialPreset = materials.first;
   this.needsRebuild = true;
   this.visible = true;

--- a/src/gfx/shaders/UberMaterial.js
+++ b/src/gfx/shaders/UberMaterial.js
@@ -29,6 +29,8 @@ var defaultUniforms = THREE.UniformsUtils.merge([
     'projMatrixInv': {type: '4fv', value: new THREE.Matrix4()},
     'viewport': {type: 'v2', value: new THREE.Vector2()},
     'lineWidth': {type: 'f', value: 2.0},
+    //default value must be the same as settings
+    'fogAlpha': {type: 'f', value: 1.0}
   }
 
 ]);
@@ -49,6 +51,7 @@ var uberOptionNames = [
   'projMatrixInv',
   'viewport',
   'lineWidth',
+  'fogAlpha'
 ];
 
 function UberMaterial(params) {
@@ -134,6 +137,7 @@ UberMaterial.prototype.uberOptions = {
   projMatrixInv: new THREE.Matrix4(),
   viewport: new THREE.Vector2(800, 600),
   lineWidth: 2.0,
+  fogAlpha: 1.0,
 
   copy: function(source) {
     this.diffuse.copy(source.diffuse);
@@ -152,6 +156,7 @@ UberMaterial.prototype.uberOptions = {
     this.viewport = source.viewport;
     this.lineWidth = source.lineWidth; // used for thick lines only
     this.toonShading = source.toonShading;
+    this.fogAlpha = source.fogAlpha;
   }
 };
 

--- a/src/gfx/shaders/Uber_frag.glsl
+++ b/src/gfx/shaders/Uber_frag.glsl
@@ -32,6 +32,7 @@ uniform float clipPlaneValue;
 
 #ifdef USE_FOG
   uniform vec3 fogColor;
+  uniform float fogAlpha;
   uniform float fogNear;
   uniform float fogFar;
 #endif
@@ -443,7 +444,7 @@ void main() {
     #ifdef FOG_TRANSPARENT
       gl_FragColor.a = gl_FragColor.a * (1.0 - fogFactor);
     #else
-      gl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );
+      gl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor * fogAlpha);
     #endif
   #endif
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -572,8 +572,10 @@ var defaults = {
    * @instance
    */
   fogFarFactor: 1, //[0, 1]
+  fogAlpha : 1.0,
   fogColor: 0x000000,
   fogColorEnable: false,
+
   /*
      * Palette used for molecule coloring.
      * @type {string}


### PR DESCRIPTION
## Description
Added fogAlpha to make a part of molecule behind fogFarFactor colored by fogColor * fogAlpha. It's possible to change fogAlpha using terminal.

## Motivation and Context
FogAlpa is a new feature.

## How Has This Been Tested?
Tests e2e were passed.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
