### PR TITLE
Fix transparent

### DIFF
--- a/src/gfx/gfxutils.js
+++ b/src/gfx/gfxutils.js
@@ -377,7 +377,7 @@ function processTransparentMaterial(root, material) {
     prepassMat.setValues({prepassTransparancy: true, fakeOpacity: false});
     var prepassMesh = new mesh.constructor(mesh.geometry, prepassMat);
     prepassMesh.material.transparent = false;
-    prepassMesh.material.colorFromDepth = true;
+    prepassMesh.material.colorFromDepth = false;
     prepassMesh.material.lights = false;
     prepassMesh.material.shadowmap = false;
     prepassMesh.material.fog = false;

--- a/src/gfx/gfxutils.js
+++ b/src/gfx/gfxutils.js
@@ -377,6 +377,10 @@ function processTransparentMaterial(root, material) {
     prepassMat.setValues({prepassTransparancy: true, fakeOpacity: false});
     var prepassMesh = new mesh.constructor(mesh.geometry, prepassMat);
     prepassMesh.material.transparent = false;
+    prepassMesh.material.colorFromDepth = true;
+    prepassMesh.material.lights = false;
+    prepassMesh.material.shadowmap = false;
+    prepassMesh.material.fog = false;
     prepassMesh.material.needsUpdate = true;
     prepassMesh.applyMatrix(mesh.matrix);
     prepassMesh.layers.set(LAYERS.PREPASS_TRANSPARENT);


### PR DESCRIPTION
## Description
Exclude extra defines for materials in PREPASS_TRANSPARENT layer

## Motivation and Context
This change makes uberfragmentShader shorter for rendering objects from PREPASS_TRANSPARENT layer and as result quicker. It also prevents some errors that may occur when shader changes.

## How Has This Been Tested?
e2e tests passed

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
