### PR TITLE
fix backdrop material

### DIFF
--- a/src/gfx/materials.js
+++ b/src/gfx/materials.js
@@ -22,7 +22,8 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: false,
-      toonShading: false
+      toonShading: false,
+      side: THREE.DoubleSide
     }
   }, {
     id: 'SF',
@@ -39,7 +40,8 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: false,
-      toonShading: false
+      toonShading: false,
+      side: THREE.DoubleSide
     }
   }, {
     id: 'PL',
@@ -56,7 +58,8 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: false,
-      toonShading: false
+      toonShading: false,
+      side: THREE.DoubleSide
     }
   }, {
     id: 'ME',
@@ -73,7 +76,8 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: false,
-      toonShading: false
+      toonShading: false,
+      side: THREE.DoubleSide
     }
   }, {
     id: 'TR',
@@ -90,7 +94,8 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: true,
-      toonShading: false
+      toonShading: false,
+      side: THREE.DoubleSide
     }
   }, {
     id: 'GL',
@@ -108,7 +113,8 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: true,
-      toonShading: false
+      toonShading: false,
+      side: THREE.DoubleSide
     }
   }, {
     id: 'BA',
@@ -120,9 +126,10 @@ var materialList = [
     values: {
       lights: false,
       fog: false,
-      depthWrite: false,
+      depthWrite: true,
       transparent: false,
-      toonShading: false
+      toonShading: false,
+      side: THREE.BackSide
     }
   }, {
     id: 'TN',
@@ -139,7 +146,8 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: false,
-      toonShading: true
+      toonShading: true,
+      side: THREE.DoubleSide
     }
   }, {
     id: 'FL',
@@ -156,6 +164,7 @@ var materialList = [
       fog: true,
       depthWrite: true,
       transparent: false,
+      side: THREE.DoubleSide
     }
   }
 ];


### PR DESCRIPTION
## Description
Solve problem: "Backdrop material works inconsistently"

## Motivation and Context
This change solves follow problem: 
"Backdrop material works inconsistently", v0.7.19, "Open miew with 1CRN by default, change the second representation to Quick Surface, Backdrop Material (and "all" selector). It hides the first representation. Expected: it serves as a backdrop."

## How Has This Been Tested?
e2e tests passed

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
