### PR TITLE
Fix molecule disappering when SSAO-on and FXAA-off at the same time

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -1096,8 +1096,9 @@ Miew.prototype._renderScene = (function () {
 
     const bHaveComplexes = (this._getComplexVisual() !== null);
     const volumeVisual = this._getVolumeVisual();
+    const ssao = bHaveComplexes && settings.now.ao;
 
-    if (bHaveComplexes && settings.now.ao) {
+    if (ssao) {
       this._setMRT(gfx.offscreenBuf, gfx.offscreenBuf4);
     }
 
@@ -1112,10 +1113,10 @@ Miew.prototype._renderScene = (function () {
     const outline = bHaveComplexes && settings.now.outline.on;
     const fxaa = bHaveComplexes && settings.now.fxaa;
     const volume = (volumeVisual !== null) && (volumeVisual.getMesh().material != null);
-    let dstBuffer = (outline || volume || fxaa || distortion) ? gfx.offscreenBuf2 : target;
+    let dstBuffer = (ssao || outline || volume || fxaa || distortion) ? gfx.offscreenBuf2 : target;
     let srcBuffer = gfx.offscreenBuf;
 
-    if (bHaveComplexes && settings.now.ao) {
+    if (ssao) {
       this._performAO(
         srcBuffer,
         gfx.offscreenBuf4,
@@ -1124,6 +1125,9 @@ Miew.prototype._renderScene = (function () {
         gfx.offscreenBuf3,
         gfx.offscreenBuf2,
       );
+      if (!fxaa && !distortion && !volume && !outline) {
+        gfx.renderer.renderScreenQuadFromTex(dstBuffer.texture, 1.0, target);
+      }
     } else {
       // just copy color buffer to dst buffer
       gfx.renderer.renderScreenQuadFromTex(srcBuffer.texture, 1.0, dstBuffer);


### PR DESCRIPTION
## Description

Molecule disappers when SSAO-on and FXAA-off at the same time. This change solve it.

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
