### PR TITLE
Fixed decreased performance bug with simultaneous representation volume and molecules 

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -1345,10 +1345,9 @@ Miew.prototype._renderVolume = (function () {
     // prepare texture that contains molecule positions
     world2colorMat.getInverse(mesh.matrixWorld);
     UberMaterial.prototype.uberOptions.world2colorMatrix.multiplyMatrices(cubeOffsetMat, world2colorMat);
-    this._setUberMaterialValues({ colorFromPos: true });
+    camera.layers.set(gfxutils.LAYERS.COLOR_FROM_POSITION);
     gfx.renderer.setRenderTarget(tmpBuf3);
     gfx.renderer.render(gfx.scene, camera);
-    this._setUberMaterialValues({ colorFromPos: false });
 
     // render volume
     const vm = mesh.material;

--- a/src/gfx/Representation.js
+++ b/src/gfx/Representation.js
@@ -67,6 +67,8 @@ class Representation {
 
     this.geo = this.mode.buildGeometry(complex, this.colorer, 1 << this.index, this.material);
 
+    gfxutils.processColFromPosMaterial(this.geo, this.material);
+
     if (this.material.uberOptions.opacity < 0.99 && settings.now.transparency === 'prepass') {
       gfxutils.processTransparentMaterial(this.geo, this.material);
     }


### PR DESCRIPTION
## Description

These changes solve the problem with recompiling pixel material shader on each frame when volume and molecules are represented at the same time. This problem is demonstrated in dramatically decreased fps with simultaneous representation volume and molecules.

To avoid recompiling shaders on each frame there are creating once on building stage "color from position" meshes, these meshes are cloned from origin meshes. And then these meshes are used on each frame for creating texture with distance to molecules.

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
