### PR TITLE
Fix normals

### DIFF
--- a/src/gfx/geometries/ExtrudedObjectsGeometry.js
+++ b/src/gfx/geometries/ExtrudedObjectsGeometry.js
@@ -76,83 +76,70 @@ class ExtrudedObjectsGeometry extends ChunkedObjectsGeometry {
         tmpShape[j].copy(shape[j]).applyMatrix4(mtx);
       }
 
-      for (let j = 0; j < ptsCount; ++j) {
+      for (let j = 0; j < ptsCount; ++j, innerPtIdx += VEC_SIZE) {
         const point = tmpShape[j];
-        const nextPt = tmpShape[(j + 1) % ptsCount];
-        const prevPt = tmpShape[(j + ptsCount - 1) % ptsCount];
+        const nxPt = tmpShape[(j + 1) % ptsCount];
+        const prPt = tmpShape[(j + ptsCount - 1) % ptsCount];
 
         const vtxIdx = chunkStartIdx + innerPtIdx;
-        const vtxIdxInPrevRing = vtxIdx - nPtsInRing;
-        const vtxIdxInPrevPrevRing = vtxIdx - 2 * nPtsInRing;
+        const prRingPt = new THREE.Vector3().fromArray(positions, vtxIdx - nPtsInRing);
+        const normInPrevRingPt = new THREE.Vector3().fromArray(normals, vtxIdx - nPtsInRing);
+        const prPrRingNormal = new THREE.Vector3().fromArray(normals, vtxIdx - 2 * nPtsInRing);
 
+        point.toArray(positions, vtxIdx);
+        this._countNormals(point, nxPt, prPt, prRingPt, prPrRingNormal, (i === 1), hasSlope).toArray(normals, vtxIdx);
 
-        positions[vtxIdx] = point.x;
-        positions[vtxIdx + 1] = point.y;
-        positions[vtxIdx + 2] = point.z;
-
-        // Counting normals:
-        // - No slope
-        //   Radius doesn't change throught part => normals are parallel with the plane contains section points
-        //   normal = vToPrevPointInSection + vToNextPointInSection (all vectors are scaled for being 1 in length)
-        // - Slope
-        //   Radius changes throught part => normals aren't parallel with the plane contains section points
-        //   normal = vTangentInSectionPlane x vToSuchPointInPrevSection (all vectors are scaled for being 1 in length)
-        if (hasSlope) {
-          if (i === 1) {
-            // first section is equal to last section of previous part so we takes normals from it
-            tmpPrev.x = normals[vtxIdxInPrevPrevRing];
-            tmpPrev.y = normals[vtxIdxInPrevPrevRing + 1];
-            tmpPrev.z = normals[vtxIdxInPrevPrevRing + 2];
-          } else {
-            // zero and first sections are equal so we will have tmpNext = 0 for the first section
-            // so we count normals with another way for it
-            tmpPrev.subVectors(prevPt, nextPt).normalize();
-            tmpNext.x = point.x - positions[vtxIdxInPrevRing];
-            tmpNext.y = point.y - positions[vtxIdxInPrevRing + 1];
-            tmpNext.z = point.z - positions[vtxIdxInPrevRing + 2];
-            tmpNext.normalize();
-            tmpPrev.crossVectors(tmpPrev, tmpNext).normalize();
-          }
-        } else {
-          tmpPrev.subVectors(point, prevPt).normalize();
-          tmpNext.subVectors(point, nextPt).normalize();
-          tmpPrev.add(tmpNext).normalize();
+        if (!hasCut) {
+          continue;
         }
-
-        normals[vtxIdx] = tmpPrev.x;
-        normals[vtxIdx + 1] = tmpPrev.y;
-        normals[vtxIdx + 2] = tmpPrev.z;
 
         // zero and first sections lies in one plane and normals for all their points are orthogonal with this plane
         // second section points are shifted into first section points for having sharp angle on the end of cut
-        if (hasCut) {
-          switch (i) {
-            case 0:
-              tmpPrev.subVectors(point, prevPt).normalize();
-              tmpNext.subVectors(point, nextPt).normalize();
-              tmpPrev.crossVectors(tmpNext, tmpPrev).normalize();
+        switch (i) {
+          case 0:
+            tmpPrev.subVectors(point, prPt).normalize();
+            tmpNext.subVectors(point, nxPt).normalize();
+            tmpPrev.crossVectors(tmpNext, tmpPrev).normalize();
 
-              normals[vtxIdx] = tmpPrev.x;
-              normals[vtxIdx + 1] = tmpPrev.y;
-              normals[vtxIdx + 2] = tmpPrev.z;
-              break;
-            case 1:
-              normals[vtxIdx] = normals[vtxIdxInPrevRing];
-              normals[vtxIdx + 1] = normals[vtxIdxInPrevRing + 1];
-              normals[vtxIdx + 2] = normals[vtxIdxInPrevRing + 2];
-              break;
-            case 2:
-              positions[vtxIdx] = positions[vtxIdxInPrevRing];
-              positions[vtxIdx + 1] = positions[vtxIdxInPrevRing + 1];
-              positions[vtxIdx + 2] = positions[vtxIdxInPrevRing + 2];
-              break;
-            default:
-              break;
-          }
+            tmpPrev.toArray(normals, vtxIdx);
+            break;
+          case 1:
+            normInPrevRingPt.toArray(normals, vtxIdx);
+            break;
+          case 2:
+            prRingPt.toArray(positions, vtxIdx);
+            break;
+          default:
+            break;
         }
-        innerPtIdx += VEC_SIZE;
       }
     }
+  }
+
+  // Counting normals:
+  // - No slope
+  //   Radius doesn't change throught part => normals are parallel with the plane contains section points
+  //   normal = vToPrevPointInSection + vToNextPointInSection (all vectors are scaled for being 1 in length)
+  // - Slope
+  //   Radius changes throught part => normals aren't parallel with the plane contains section points
+  //   normal = vTangentInSectionPlane x vToSuchPointInPrevSection (all vectors are scaled for being 1 in length)
+
+  _countNormals(point, nextPt, prevPt, prevRingPt, prevPrevRingNormal, isFirstRing, hasSlope) {
+    if (hasSlope) {
+      if (isFirstRing) {
+        // first section is equal to last section of previous part so we takes normals from it
+        return prevPrevRingNormal;
+      }
+      // zero and first sections are equal so we will have tmpNext = 0 for the first section
+      // so we count normals with another way for it
+      tmpPrev.subVectors(prevPt, nextPt).normalize();
+      tmpNext.subVectors(point, prevRingPt).normalize();
+      return new THREE.Vector3().crossVectors(tmpPrev, tmpNext).normalize();
+    }
+
+    tmpPrev.subVectors(point, prevPt).normalize();
+    tmpNext.subVectors(point, nextPt).normalize();
+    return new THREE.Vector3().addVectors(tmpPrev, tmpNext).normalize();
   }
 }
 

--- a/src/gfx/modes/groups/ResiduesSubseqGroup.js
+++ b/src/gfx/modes/groups/ResiduesSubseqGroup.js
@@ -7,7 +7,7 @@ function _createShape(rad, parts) {
 
   for (let i = 0; i < parts; ++i) {
     // starts from pi/2 because it's important that points are lied on the angles of arrows (visual issues if not)
-    const a = Math.PI / 2.0 + 2 * i / parts * Math.PI;
+    const a = Math.PI / 2.0 + 2 * Math.PI * i / parts;
 
     pts.push(new THREE.Vector3(Math.cos(a) * rad, Math.sin(a) * rad, 0));
   }

--- a/src/gfx/modes/groups/ResiduesSubseqGroup.js
+++ b/src/gfx/modes/groups/ResiduesSubseqGroup.js
@@ -6,7 +6,8 @@ function _createShape(rad, parts) {
   const pts = [];
 
   for (let i = 0; i < parts; ++i) {
-    const a = 2 * i / parts * Math.PI;
+    // starts from pi/2 because it's important that points are lied on the angles of arrows (visual issues if not)
+    const a = Math.PI / 2.0 + 2 * i / parts * Math.PI;
 
     pts.push(new THREE.Vector3(Math.cos(a) * rad, Math.sin(a) * rad, 0));
   }
@@ -23,6 +24,7 @@ function _loopThrough(subDiv, residues, segmentsHeight, tension, mode, callback)
       let prevLast = null;
       const startIdx = subs[i].start * 2;
       const endIdx = subs[i].end * 2 + 1;
+      let prevSecondRad = mode.getResidueRadius(residues[0], 0);
       for (let idx = startIdx; idx <= endIdx; ++idx) {
         const resIdx = (idx / 2 | 0);
         const currRes = residues[resIdx];
@@ -32,8 +34,15 @@ function _loopThrough(subDiv, residues, segmentsHeight, tension, mode, callback)
         const mtc = matrixHelper.prepareMatrices(idx - idc[0] * 2, firstRad, secondRad);
         mtc.unshift(prevLast === null ? mtc[0] : prevLast);
 
-        callback(currRes, mtc, resIdx);
+        // Slope - radius is changed along this residue part
+        const hasSlope = (firstRad.x !== secondRad.x) || (firstRad.y !== secondRad.y);
+        // Cut - end radius of previous part not equal to start radius of this part. First section of this part lies in the orthogonal plane
+        const hasCut = (firstRad.x !== prevSecondRad.x) || (firstRad.y !== prevSecondRad.y);
+
+        callback(currRes, mtc, hasSlope, hasCut);
+
         prevLast = mtc[segmentsHeight];
+        prevSecondRad = secondRad;
       }
     }
   }
@@ -54,10 +63,10 @@ class ResiduesSubseqGroup extends ResiduesGroup {
     const geo = this._geo;
     let chunkIdx = 0;
     const chunkIdc = [];
-    _loopThrough(this._selection.subdivs, residues, this._segmentsHeight, tension, mode, (currRes, mtc) => {
+    _loopThrough(this._selection.subdivs, residues, this._segmentsHeight, tension, mode, (currRes, mtc, hasSlope = false, hasCut = false) => {
       const color = colorer.getResidueColor(currRes, parent);
       chunkIdc[chunkIdx] = currRes._index;
-      geo.setItem(chunkIdx, mtc);
+      geo.setItem(chunkIdx, mtc, hasSlope, hasCut);
       geo.setColor(chunkIdx++, color);
     });
     this._chunksIdc = chunkIdc;

--- a/src/settings.js
+++ b/src/settings.js
@@ -75,7 +75,7 @@ const defaults = {
       aromrad: 0.1,
       showarom: true,
       polyComplexity: {
-        poor: 2,
+        poor: 3,
         low: 4,
         medium: 6,
         high: 12,

--- a/src/settings.js
+++ b/src/settings.js
@@ -339,7 +339,7 @@ const defaults = {
       heightSegmentsRatio: 1.5,
       tension: -0.7,
       polyComplexity: {
-        poor: 5,
+        poor: 4,
         low: 6,
         medium: 10,
         high: 18,
@@ -365,6 +365,7 @@ const defaults = {
      * @proprety {number} ss.helix.arrow - Secondary structure's arrow width.
      * @proprety {object} ss.strand - Options for strands render.
      * @property {PolyComplexity} polyComplexity - Polygonal complexity settings for different resolutions.
+     * polyComplexity must be even for producing symmetric arrows.
      * @property {number} heightSegmentsRatio - Poly complexity multiplier for height segments.
      */
     CA: {
@@ -383,7 +384,7 @@ const defaults = {
       heightSegmentsRatio: 1.5,
       tension: -0.7,
       polyComplexity: {
-        poor: 5,
+        poor: 4,
         low: 6,
         medium: 10,
         high: 18,


### PR DESCRIPTION
## Description

- Fix normals counting for Cartoon mode;
- Rotate base shape for Cartoon and Tube modes (for having points on angles of arrows in Cartoon mode);
- Change value of PolyComplexity.poor for:
  - BallsandSticks mode because three points give a much better result than two,
  - Cartoon and Tube modes because old value five produce asymmetric arrows in Cartoon mode (visual defect).

These changes effects on golden tests results. It is needed to upload new pictures for Tube and Cartoon mode

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [ ] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
