### PR TITLE
Fix initializing gfx.renderer.shadowMap

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -364,7 +364,7 @@ Miew.prototype._initGfx = function () {
   gfx.renderer2d = new CSS2DRenderer();
 
   gfx.renderer = new THREE.WebGLRenderer(webGLOptions);
-  gfx.renderer.shadowMap.enabled = false;
+  gfx.renderer.shadowMap.enabled = settings.now.shadow.on;
   gfx.renderer.shadowMap.type = THREE.PCFShadowMap;
   capabilities.init(gfx.renderer);
 


### PR DESCRIPTION
## Description

Initialize gfx.renderer.shadowMap using the value of settings.now.shadow.on

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
