### PR TITLE
Drawing volume density frame 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,7 @@ version: "2"
 plugins:
   eslint:
     enabled: true
+    channel: "eslint-5"
   fixme:
     enabled: true
   duplication:

--- a/src/Miew.js
+++ b/src/Miew.js
@@ -3510,6 +3510,11 @@ Miew.prototype._initOnSettingsChanged = function () {
     });
   };
 
+  on('modes.VD.frame', () => {
+    this._getVolumeVisual().showFrame(settings.now.modes.VD.frame);
+    this._needRender = true;
+  });
+
   on('theme', () => {
     // TODO add warning
     this._onThemeChanged();

--- a/src/VolumeVisual.js
+++ b/src/VolumeVisual.js
@@ -15,8 +15,9 @@ function VolumeVisual(name, dataSource) {
   this._mesh.setDataSource(dataSource);
   this.add(this._mesh);
 
-  this._boundaries = new VolumeBounds(this);
-  this.showFrame(true);//settings.now.modes.VD.frame);
+  this._frame = new VolumeBounds(this.getBoundaries().boundingBox, this._mesh.volumeInfo);
+  this.add(this._frame.getMesh());
+  this.showFrame(settings.now.modes.VD.frame);
 
   this.buildFarPlane();
 }
@@ -86,11 +87,7 @@ VolumeVisual.prototype.getMesh = function () {
 };
 
 VolumeVisual.prototype.showFrame = function (needShow) {
-  if (needShow) {
-    this.add(this._boundaries.getMesh());
-  } else {
-    this.remove(this._boundaries.getMesh());
-  }
+  this._frame.getMesh().material.visible = needShow;
 };
 
 export default VolumeVisual;

--- a/src/VolumeVisual.js
+++ b/src/VolumeVisual.js
@@ -1,10 +1,12 @@
 import * as THREE from 'three';
 import utils from './utils';
 import VolumeMesh from './gfx/VolumeMesh';
+import VolumeBounds from './gfx/VolumeBounds';
 import Visual from './Visual';
 import VolumeMaterial from './gfx/shaders/VolumeMaterial';
 import gfxutils from './gfx/gfxutils';
 import meshes from './gfx/meshes/meshes';
+import settings from './settings';
 
 function VolumeVisual(name, dataSource) {
   Visual.call(this, name, dataSource);
@@ -12,6 +14,9 @@ function VolumeVisual(name, dataSource) {
   this._mesh = new VolumeMesh();
   this._mesh.setDataSource(dataSource);
   this.add(this._mesh);
+
+  this._boundaries = new VolumeBounds(this);
+  this.showFrame(true);//settings.now.modes.VD.frame);
 
   this.buildFarPlane();
 }
@@ -78,6 +83,14 @@ VolumeVisual.prototype.getBoundaries = function () {
 
 VolumeVisual.prototype.getMesh = function () {
   return this._mesh;
+};
+
+VolumeVisual.prototype.showFrame = function (needShow) {
+  if (needShow) {
+    this.add(this._boundaries.getMesh());
+  } else {
+    this.remove(this._boundaries.getMesh());
+  }
 };
 
 export default VolumeVisual;

--- a/src/gfx/VolumeBounds.js
+++ b/src/gfx/VolumeBounds.js
@@ -1,0 +1,50 @@
+import * as THREE from 'three/src/Three';
+
+class VolumeBounds {
+  constructor(volumeVisual) {
+    const geometry = new THREE.Geometry();
+
+    const bBox = volumeVisual.getBoundaries().boundingBox;
+    const bSize = bBox.getSize().multiplyScalar(0.5);
+    const { delta } = volumeVisual.getMesh().volumeInfo; // {x: XY, y : XZ, z: YZ}
+    const { obtuseAngle } = volumeVisual.getMesh().volumeInfo;
+
+    const projTable = {
+      XY: ['x', 2],
+      XZ: ['y', 1],
+      YZ: ['z', 0],
+    };
+
+    const proj = ((index, inv) => {
+      const currDelta = delta[projTable[index][0]];
+      const angleValue = -0.5 * (inv - 1) + inv * obtuseAngle[projTable[index][1]];// inv = 1: alpha; inv = -1: 1 - alpha
+      return angleValue * currDelta;
+    });
+    const offsetVert = [
+      new THREE.Vector3(-1 + 2 * (proj('XZ', 1) + proj('XY', 1)), -1 + 2 * proj('YZ', 1), -1),
+      new THREE.Vector3(-1 + 2 * (proj('XZ', -1) + proj('XY', 1)), -1 + 2 * proj('YZ', -1), 1),
+      new THREE.Vector3(-1 + 2 * (proj('XZ', -1) + proj('XY', -1)), 1 - 2 * proj('YZ', 1), 1),
+      new THREE.Vector3(-1 + 2 * (proj('XZ', 1) + proj('XY', -1)), 1 - 2 * proj('YZ', -1), -1),
+    ];
+    for (let i = 0; i < 4; i++) {
+      geometry.vertices.push(offsetVert[i].clone().multiply(bSize));
+      geometry.vertices.push(offsetVert[(i + 1) % 4].clone().multiply(bSize));
+    }
+    const translation = new THREE.Vector3(2 * bSize.x * (1 - delta.x - delta.y), 0, 0);
+    for (let i = 0; i < 8; i++) {
+      geometry.vertices.push(geometry.vertices[i].clone().add(translation));
+    }
+    for (let i = 0; i < 4; i++) {
+      geometry.vertices.push(geometry.vertices[i * 2].clone());
+      geometry.vertices.push(geometry.vertices[i * 2 + 8].clone());
+    }
+    geometry.vertices.forEach(vertex => vertex.add(bBox.getCenter()));
+    this._lines = new THREE.LineSegments(geometry, new THREE.LineBasicMaterial({ color: 0xFFFFFF }));
+  }
+
+  getMesh() {
+    return this._lines;
+  }
+}
+
+export default VolumeBounds;

--- a/src/gfx/gfxutils.js
+++ b/src/gfx/gfxutils.js
@@ -325,7 +325,7 @@ function removeChildren(object) {
 
 function clearTree(object) {
   object.traverse((obj) => {
-    if (obj instanceof THREE.Mesh) {
+    if (obj instanceof THREE.Mesh || obj instanceof THREE.LineSegments || obj instanceof THREE.Line) {
       obj.geometry.dispose();
     }
   });

--- a/src/settings.js
+++ b/src/settings.js
@@ -432,13 +432,15 @@ const defaults = {
      *
      * @typedef VolumeDensityModeOptions
      *
-     * @property {number} kSigma - Noise threshold coefficient .
+     * @property {number} kSigma - Noise threshold coefficient.
+     * @property {boolean} frame - flag, that turns on box frame painting
      *
      */
     VD: {
       kSigma: 1.0,
       kSigmaMed: 2.0,
       kSigmaMax: 4.0,
+      frame: true,
     },
   },
 


### PR DESCRIPTION
## Description

This functionality helps better to understand the borders of volume density data.

There is a new mesh of segment lines geometry, which is connected to VolumeVisual. This mesh is a frame of origin (experimental) parallelepiped.

To turn off/on the frame it is necessary to command: set modes.VD.frame false/true
By default it is visible.

![image](https://user-images.githubusercontent.com/22669290/56657991-1edc4d00-66a2-11e9-8ece-612b8f32475a.png)

## Type of changes

- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
