### PR TITLE
Fix: Selection field information does not update

### DIFF
--- a/demo/scripts/ui/Menu.js
+++ b/demo/scripts/ui/Menu.js
@@ -1915,7 +1915,8 @@ Menu.prototype.show = function (panelID, menuItem) {
   });
 
   // renew currently opened mode-, colorer-, matpreset- combobox panel (need, when they were changed from toolbar)
-  if (self._curPanelID.indexOf('mode') !== -1
+  if (self._curPanelID.indexOf('selection') !== -1
+    || self._curPanelID.indexOf('mode') !== -1
     || self._curPanelID.indexOf('color') !== -1
     || self._curPanelID.indexOf('matpreset') !== -1) {
     const reprList = $(`${self._menuId} [data-panel-type=miew-menu-panel-representation] .miew-repr-list`);


### PR DESCRIPTION
## Description

Fix: Selection field information does not refresh if Terminal was used to change selection

For reproduce it:

**Preconditions:**
- Run Miew
- Open Menu
- Select Representations
- Select Selection
- Close Menu

**Actions:**
- Open the Terminal
- Enter and execute: selector "elem N" (or any other valid selector)
- Open Menu

**Expected result:**
There is "Elem N" in selection field

**Actual result:**
There is still previous selection string.

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
