### PR TITLE
Improve raycasting performance

### DIFF
--- a/src/gfx/gfxutils.js
+++ b/src/gfx/gfxutils.js
@@ -10,6 +10,10 @@ const LAYERS = {
   DEFAULT: 0, VOLUME: 1, TRANSPARENT: 2, PREPASS_TRANSPARENT: 3, VOLUME_BFPLANE: 4, COLOR_FROM_POSITION: 5,
 };
 
+const SELECTION_LAYERS = [ // These layers, that are used in the selection by ray casting
+  'DEFAULT', 'TRANSPARENT',
+];
+
 THREE.Object3D.prototype.resetTransform = function () {
   this.position.set(0, 0, 0);
   this.quaternion.set(0, 0, 0, 1);
@@ -353,6 +357,15 @@ function destroyObject(object) {
   }
 }
 
+function belongToSelectLayers(object) {
+  for (let i = 0; i < SELECTION_LAYERS.length; i++) {
+    if (object.layers.mask >> LAYERS[SELECTION_LAYERS[i]] === 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function _getMeshesArr(root, meshTypes) {
   const meshes = [];
   root.traverse((object) => {
@@ -523,6 +536,7 @@ export default {
   fillArray,
   clearTree,
   destroyObject,
+  belongToSelectLayers,
   applyTransformsToMeshes,
   processTransparentMaterial,
   processColFromPosMaterial,

--- a/src/gfx/gfxutils.js
+++ b/src/gfx/gfxutils.js
@@ -11,7 +11,7 @@ const LAYERS = {
 };
 
 const SELECTION_LAYERS = [ // These layers, that are used in the selection by ray casting
-  'DEFAULT', 'TRANSPARENT',
+  LAYERS.DEFAULT, LAYERS.TRANSPARENT,
 ];
 
 THREE.Object3D.prototype.resetTransform = function () {
@@ -359,7 +359,7 @@ function destroyObject(object) {
 
 function belongToSelectLayers(object) {
   for (let i = 0; i < SELECTION_LAYERS.length; i++) {
-    if (object.layers.mask >> LAYERS[SELECTION_LAYERS[i]] === 1) {
+    if (((object.layers.mask >> SELECTION_LAYERS[i]) & 1) === 1) {
       return true;
     }
   }

--- a/src/gfx/meshes/TransformGroup.js
+++ b/src/gfx/meshes/TransformGroup.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import gfxutils from '../gfxutils';
 
 class TransformGroup extends THREE.Object3D {
   static _inverseMatrix = new THREE.Matrix4();
@@ -26,6 +27,11 @@ class TransformGroup extends THREE.Object3D {
     ray.copy(raycaster.ray);
     for (let i = 0, n = children.length; i < n; ++i) {
       const child = children[i];
+
+      if (!gfxutils.belongToSelectLayers(child)) {
+        continue;
+      }
+
       child.updateMatrixWorld();
       const mtx = child.matrixWorld;
       // TODO check near / far?


### PR DESCRIPTION
## Description

This change fixes part of the problem with fps subsidence in selection.
Meshes with the same geometry now are checked for intersection with the ray only once.

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
