### PR TITLE
Fix error when display mode/color buttons are used without a representations

### DIFF
--- a/demo/scripts/ui/Menu.js
+++ b/demo/scripts/ui/Menu.js
@@ -969,10 +969,10 @@ Menu.prototype._init = function () {
     });
 
     const elements = $(`${self._menuId} [data-toolbar-type=${toolbar}]`);
-    elements.toggle();
-    this.classList.toggle('active');
-
     if (toolbar === 'miew-menu-toolbar-resolution') {
+      elements.toggle();
+      this.classList.toggle('active');
+
       const resSelector = $(`${self._menuId} [data-toggle="resolution-immediate"]`
           + `[data-value="${settings.now.resolution}"]`);
       if (this.classList.contains('active') === true) {
@@ -981,13 +981,21 @@ Menu.prototype._init = function () {
         resSelector.removeClass('active');
       }
     } else {
-      const type = toolbar.substr(toolbar.lastIndexOf('-') + 1, toolbar.length);
-      const selector = $(`${self._menuId} [data-toggle="${type}-immediate"]`
-          + `[data-value="${unarray(self._viewer.rep()[type])}"]`);
-      if (this.classList.contains('active') === true) {
-        selector.addClass('active');
+      const curRep = self._viewer.rep();
+      if (curRep !== null) {
+        elements.toggle();
+        this.classList.toggle('active');
+
+        const type = toolbar.substr(toolbar.lastIndexOf('-') + 1, toolbar.length);
+        const selector = $(`${self._menuId} [data-toggle="${type}-immediate"]`
+            + `[data-value="${unarray(curRep[type])}"]`);
+        if (this.classList.contains('active') === true) {
+          selector.addClass('active');
+        } else {
+          selector.removeClass('active');
+        }
       } else {
-        selector.removeClass('active');
+        self._viewer.logger.error('No representation');
       }
     }
   });


### PR DESCRIPTION
## Description

Miew gives an error when display mode/color buttons are used without a representation existed

There are to ways to reproduce this bug:


**Preconditions 1:**
- Run Miew
- Open Menu
- Select Load
- Write something that is not a molecule name. For example "a"
- Press Load button

**Preconditions 1:**
- Run Miew
- Open Menu
- Select Load
- Select electron density file
- Press Load button

**Actions:**
Press "Display mode" or "Display color" button

**Expected result:**
A warning message or disabled icon

**Actual result:**
An error occur

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
