### PR TITLE
Selection notation stays when selection was changed via the Terminal

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -3599,6 +3599,8 @@ Miew.prototype.select = function (expression, append) {
   }
 
   visual.select(sel, append);
+  this._lastPick = null;
+
   this._updateInfoPanel();
   this._needRender = true;
 };


### PR DESCRIPTION
## Description

Selection notation stays when selection was changed via the Terminal

**Preconditions:**
- Run Miew
- Select any aminoacid with your mouse
- Look at selection notation
- Open the Terminal
- Actions:
- Execute select "residue ala"

**Expected result:**
The notation vanishes

**Actual result:**
The notation stays

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
