### PR TITLE
Update selection notification when unit changes

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -2244,6 +2244,7 @@ Miew.prototype.changeUnit = function (unitIdx, name) {
   }
   if (visual.getComplex().setCurrentUnit(unitIdx)) {
     this._resetScene();
+    this._updateInfoPanel();
   }
   return currentUnitInfo();
 };


### PR DESCRIPTION
## Description

Remove redundant selection notification

**Preconditions:**
- Run Miew
- Open the Terminal
- Enter and execute:
- load 4tnw
- mode bs
- unit 1
- select "name OG1" as og1s
- Observe selection is highlighted and notification message appears

**Actions:**
- Change unit to unit 2
- Observe the notification message is still visible
- Change unit back to unit 1
- Observe the molecule

**Expected result:**
Notification message vanishes after unit is switched

**Actual result:**
There is no selection highlighted and notification message is still visible

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
