### PR TITLE
Fix screenshot inverting in Safari

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -3042,37 +3042,34 @@ Miew.prototype.screenshot = function (width, height) {
     return THREE.Math.radToDeg(Math.atan(tan)) * 2.0;
   }
 
-  function getScreenshotSafari() {
-    const canvas = document.createElement('canvas');
-    const canvasContext = canvas.getContext('2d');
+  function getDataURL() {
+    let dataURL;
+    const currBrowser = utils.getBrowser();
 
-    canvas.width = width;
-    canvas.height = height;
-    canvasContext.drawImage(gfx.renderer.domElement, 0, 0, canvas.width, canvas.height);
-    const screenshot = canvas.toDataURL('image/png');
+    if (currBrowser === utils.browserType.SAFARI) {
+      const canvas = document.createElement('canvas');
+      const canvasContext = canvas.getContext('2d');
 
-    return screenshot;
+      canvas.width = width;
+      canvas.height = height;
+      canvasContext.drawImage(gfx.renderer.domElement, 0, 0, canvas.width, canvas.height);
+      dataURL = canvas.toDataURL('image/png');
+    } else {
+      // Copy current canvas to screenshot
+      dataURL = gfx.renderer.domElement.toDataURL('image/png');
+    }
+    return dataURL;
   }
   height = height || width || gfx.height;
   width = width || gfx.width;
 
-  const isSafariBrowser = navigator.vendor && navigator.vendor.indexOf('Apple') > -1
-    && navigator.userAgent
-    && navigator.userAgent.indexOf('CriOS') === -1
-    && navigator.userAgent.indexOf('FxiOS') === -1;
   let screenshotURI;
 
   if (width === gfx.width && height === gfx.height) {
     // renderer.domElement.toDataURL('image/png') returns flipped image in Safari
     // It hasn't been resolved yet, but getScreenshotSafari()
     // fixes it using an extra canvas.
-    // Also the bug can be fixed with premultipliedAlpha: true WebGL option
-    if (isSafariBrowser) {
-      screenshotURI = getScreenshotSafari();
-    } else {
-      // Copy current canvas to screenshot
-      screenshotURI = gfx.renderer.domElement.toDataURL('image/png');
-    }
+    screenshotURI = getDataURL();
   } else {
     const originalAspect = gfx.camera.aspect;
     const originalFov = gfx.camera.fov;
@@ -3093,11 +3090,7 @@ Miew.prototype.screenshot = function (width, height) {
 
     // make screenshot
     this._renderFrame(settings.now.stereo);
-    if (isSafariBrowser) {
-      screenshotURI = getScreenshotSafari();
-    } else {
-      screenshotURI = gfx.renderer.domElement.toDataURL('image/png');
-    }
+    screenshotURI = getDataURL();
 
     // restore original camera & canvas proportions
     gfx.camera.aspect = originalAspect;

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,10 @@ import _ from 'lodash';
 import logger from './utils/logger';
 
 
+const browserType = {
+  DEFAULT: 0,
+  SAFARI: 1,
+};
 //----------------------------------------------------------------------------
 // Query string
 
@@ -393,6 +397,16 @@ function dataUrlToBlob(url) {
   return null;
 }
 
+function getBrowser() {
+  if (navigator.vendor && navigator.vendor.indexOf('Apple') > -1
+    && navigator.userAgent
+    && navigator.userAgent.indexOf('CriOS') === -1
+    && navigator.userAgent.indexOf('FxiOS') === -1) {
+    return browserType.SAFARI;
+  }
+  return browserType.DEFAULT;
+}
+
 function shotOpen(url) {
   if (typeof window !== 'undefined') {
     window.open().document.write(`<body style="margin:0"><img src="${url}" /></body>`);
@@ -477,6 +491,7 @@ function correctSelectorIdentifier(value) {
 // Exports
 
 export default {
+  browserType,
   encodeQueryComponent,
   decodeQueryComponent,
   getUrlParameters,
@@ -499,6 +514,7 @@ export default {
   forInRecursive,
   enquoteString,
   unquoteString,
+  getBrowser,
   shotOpen,
   shotDownload,
   copySubArrays,


### PR DESCRIPTION
## Description
There was an issue when taking screenshots by "screenshot" terminal command in Safari web browser, it results in vertically inverted image. The problem is caused by the bug in Safari

If the Safari bug is fixed by Apple, proposed solution will still work as expected

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.