### PR TITLE
Store front/back face flag in G-buffer

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -3546,7 +3546,7 @@ Miew.prototype._initOnSettingsChanged = function () {
   });
 
   on('ao', () => {
-    const values = { normalsToGBuffer: settings.now.ao, doubleSidedGBuffer: settings.now.ao };
+    const values = { normalsToGBuffer: settings.now.ao };
     this._setUberMaterialValues(values);
   });
 

--- a/src/gfx/Representation.js
+++ b/src/gfx/Representation.js
@@ -61,7 +61,7 @@ class Representation {
     this.needsRebuild = false;
 
     if (settings.now.ao) {
-      this.material.setValues({ normalsToGBuffer: settings.now.ao, doubleSidedGBuffer: settings.now.ao });
+      this.material.setValues({ normalsToGBuffer: settings.now.ao });
     }
 
     this.geo = this.mode.buildGeometry(complex, this.colorer, 1 << this.index, this.material);

--- a/src/gfx/shaders/AO.frag
+++ b/src/gfx/shaders/AO.frag
@@ -52,7 +52,9 @@ void main() {
   //[0, 1] -> [-1, 1]
   vec4 normalData = texture2D(normalTexture, vUv);
   vec3 normal = (normalData.rgb * 2.0 - 1.0);
-  if (normalData.a < 0.5) {
+  // normalData.a store 1.0 if normal was build for frontfaced surface
+  // and 0.0 in other case
+  if (normalData.a < 0.00001) {
     normal *= -1.0;
   }
   // get random vector for sampling sphere rotation

--- a/src/gfx/shaders/AO.frag
+++ b/src/gfx/shaders/AO.frag
@@ -50,7 +50,11 @@ void main() {
   // remap coordinates to prevent noise exture rescale
   vec2 vUvNoise = vUv / srcTexelSize * noiseTexelSize;
   //[0, 1] -> [-1, 1]
-  vec3 normal = (texture2D(normalTexture, vUv).rgb * 2.0 - 1.0);
+  vec4 normalData = texture2D(normalTexture, vUv);
+  vec3 normal = (normalData.rgb * 2.0 - 1.0);
+  if (normalData.a < 0.5) {
+    normal *= -1.0;
+  }
   // get random vector for sampling sphere rotation
   vec3 randN = texture2D(noiseTexture, vUvNoise).rgb * 2.0 - 1.0;
   randN = normalize(randN);

--- a/src/gfx/shaders/Uber.frag
+++ b/src/gfx/shaders/Uber.frag
@@ -546,7 +546,7 @@ void main() {
   #if !defined (SPHERE_SPRITE) && !defined (CYLINDER_SPRITE)
     flipNormal = 1.0;
     #ifdef DOUBLE_SIDED
-      flipNormal = normalSign;
+      flipNormal = float( gl_FrontFacing );
     #endif
     vec3 normal = normalize( vNormal ) * flipNormal;
   #endif
@@ -560,17 +560,14 @@ void main() {
   #ifdef NORMALS_TO_G_BUFFER
     #if defined (SPHERE_SPRITE) || defined (CYLINDER_SPRITE)
       vec3 viewNormaInColor = viewNormalSprites;
+      float frontFaced = 1.0;
     #else
       vec3 viewNormaInColor = viewNormal;
-    #endif
-    flipNormal = 1.0;
-    // invert normals on invisible front faces to all of them been directed to the side of viewer
-    #ifdef DOUBLE_SIDED_G_BUFFER
-      flipNormal = normalSign;
+      float frontFaced = normalSign;
     #endif
     // [-1, 1] -> [0, 1]
-    viewNormaInColor = 0.5 * viewNormaInColor * flipNormal + 0.5;
-    gl_FragData[1] = vec4(viewNormaInColor, 1.0);
+    viewNormaInColor = 0.5 * viewNormaInColor + 0.5;
+    gl_FragData[1] = vec4(viewNormaInColor, frontFaced);
   #endif
 
   #if defined(USE_LIGHTS) && NUM_DIR_LIGHTS > 0

--- a/src/gfx/shaders/Uber.frag
+++ b/src/gfx/shaders/Uber.frag
@@ -58,7 +58,6 @@ uniform float clipPlaneValue;
 #define PI 3.14159265359
 #define RECIPROCAL_PI 0.31830988618
 #define saturate(a) clamp( a, 0.0, 1.0 )
-#define normalSign ( float( gl_FrontFacing ) * 2.0 - 1.0 )
 
 #ifdef USE_FOG
   uniform vec3 fogColor;
@@ -563,7 +562,7 @@ void main() {
       float frontFaced = 1.0;
     #else
       vec3 viewNormaInColor = viewNormal;
-      float frontFaced = normalSign;
+      float frontFaced = float( gl_FrontFacing );
     #endif
     // [-1, 1] -> [0, 1]
     viewNormaInColor = 0.5 * viewNormaInColor + 0.5;

--- a/src/gfx/shaders/UberMaterial.js
+++ b/src/gfx/shaders/UberMaterial.js
@@ -117,8 +117,6 @@ function UberMaterial(params) {
   this.fogTransparent = false;
   // used to render surface normals to G buffer for ssao effect
   this.normalsToGBuffer = false;
-  // used to render surface normals directed to the side of viewer to G buffer for ssao effect
-  this.doubleSidedGBuffer = false;
   // used for toon material
   this.toonShading = false;
 
@@ -227,7 +225,6 @@ UberMaterial.prototype.copy = function (source) {
   this.thickLine = source.thickLine;
   this.fogTransparent = source.fogTransparent;
   this.normalsToGBuffer = source.normalsToGBuffer;
-  this.doubleSidedGBuffer = source.doubleSidedGBuffer;
   this.toonShading = source.toonShading;
 
   this.uberOptions.copy(source.uberOptions);
@@ -327,9 +324,6 @@ UberMaterial.prototype.setValues = function (values) {
   if (this.normalsToGBuffer) {
     extensions.drawBuffers = 1;
     defines.NORMALS_TO_G_BUFFER = 1;
-  }
-  if (this.doubleSidedGBuffer) {
-    defines.DOUBLE_SIDED_G_BUFFER = 1;
   }
   if (this.toonShading) {
     defines.TOON_SHADING = 1;


### PR DESCRIPTION
## Description

Now in G buffer for storing normals are used only 3 float numbers from 4. The last one can be used for front/back face flag. As result we have flip define only for lighting and we escape nesseserity to store two normal textures: simple and flipped (such can appear later with new graphic effects)

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
