### PR TITLE
Fix screenshots size on HI-DPI and Retina devices

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -3038,6 +3038,8 @@ Miew.prototype.benchmarkGfx = function (force) {
  */
 Miew.prototype.screenshot = function (width, height) {
   const gfx = this._gfx;
+  const deviceWidth = gfx.renderer.domElement.width;
+  const deviceHeight = gfx.renderer.domElement.height;
 
   function fov2Tan(fov) {
     return Math.tan(THREE.Math.degToRad(0.5 * fov));
@@ -3055,8 +3057,9 @@ Miew.prototype.screenshot = function (width, height) {
       const canvas = document.createElement('canvas');
       const canvasContext = canvas.getContext('2d');
 
-      canvas.width = width;
-      canvas.height = height;
+      canvas.width = width === undefined ? deviceWidth : width;
+      canvas.height = height === undefined ? deviceHeight : height;
+
       canvasContext.drawImage(gfx.renderer.domElement, 0, 0, canvas.width, canvas.height);
       dataURL = canvas.toDataURL('image/png');
     } else {
@@ -3065,12 +3068,11 @@ Miew.prototype.screenshot = function (width, height) {
     }
     return dataURL;
   }
-  height = height || width || gfx.height;
-  width = width || gfx.width;
+  height = height || width;
 
   let screenshotURI;
-
-  if (window.devicePixelRatio === 1 && width === gfx.width && height === gfx.height) {
+  if ((width === undefined && height === undefined)
+    || (width === deviceWidth && height === deviceHeight)) {
     // renderer.domElement.toDataURL('image/png') returns flipped image in Safari
     // It hasn't been resolved yet, but getScreenshotSafari()
     // fixes it using an extra canvas.

--- a/src/Miew.js
+++ b/src/Miew.js
@@ -462,7 +462,7 @@ Miew.prototype._initGfx = function () {
   light12.shadow = new THREE.DirectionalLightShadow();
   light12.shadow.bias = 0.09;
   light12.shadow.radius = settings.now.shadow.radius;
-  const shadowMapSize = Math.max(gfx.width, gfx.height) * window.devicePixelRatio;
+  const shadowMapSize = Math.max(gfx.width, gfx.height) * gfx.renderer.getPixelRatio();
   light12.shadow.mapSize.width = shadowMapSize;
   light12.shadow.mapSize.height = shadowMapSize;
   light12.target.position.set(0.0, 0.0, 0.0);
@@ -477,8 +477,8 @@ Miew.prototype._initGfx = function () {
   gfx.axes = new Axes(gfx.root, gfx.camera);
 
   gfx.offscreenBuf = new THREE.WebGLRenderTarget(
-    gfx.width * window.devicePixelRatio,
-    gfx.height * window.devicePixelRatio,
+    gfx.width * gfx.renderer.getPixelRatio(),
+    gfx.height * gfx.renderer.getPixelRatio(),
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, depthBuffer: true,
     },
@@ -490,24 +490,24 @@ Miew.prototype._initGfx = function () {
   }
 
   gfx.offscreenBuf2 = new THREE.WebGLRenderTarget(
-    gfx.width * window.devicePixelRatio,
-    gfx.height * window.devicePixelRatio,
+    gfx.width * gfx.renderer.getPixelRatio(),
+    gfx.height * gfx.renderer.getPixelRatio(),
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
   );
 
   gfx.offscreenBuf3 = new THREE.WebGLRenderTarget(
-    gfx.width * window.devicePixelRatio,
-    gfx.height * window.devicePixelRatio,
+    gfx.width * gfx.renderer.getPixelRatio(),
+    gfx.height * gfx.renderer.getPixelRatio(),
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
   );
 
   gfx.offscreenBuf4 = new THREE.WebGLRenderTarget(
-    gfx.width * window.devicePixelRatio,
-    gfx.height * window.devicePixelRatio,
+    gfx.width * gfx.renderer.getPixelRatio(),
+    gfx.height * gfx.renderer.getPixelRatio(),
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
@@ -520,8 +520,8 @@ Miew.prototype._initGfx = function () {
   // use float textures for volume rendering if possible
   if (gfx.renderer.getContext().getExtension('OES_texture_float')) {
     gfx.offscreenBuf5 = new THREE.WebGLRenderTarget(
-      gfx.width * window.devicePixelRatio,
-      gfx.height * window.devicePixelRatio,
+      gfx.width * gfx.renderer.getPixelRatio(),
+      gfx.height * gfx.renderer.getPixelRatio(),
       {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
@@ -532,8 +532,8 @@ Miew.prototype._initGfx = function () {
     );
 
     gfx.offscreenBuf6 = new THREE.WebGLRenderTarget(
-      gfx.width * window.devicePixelRatio,
-      gfx.height * window.devicePixelRatio,
+      gfx.width * gfx.renderer.getPixelRatio(),
+      gfx.height * gfx.renderer.getPixelRatio(),
       {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
@@ -544,8 +544,8 @@ Miew.prototype._initGfx = function () {
     );
 
     gfx.offscreenBuf7 = new THREE.WebGLRenderTarget(
-      gfx.width * window.devicePixelRatio,
-      gfx.height * window.devicePixelRatio,
+      gfx.width * gfx.renderer.getPixelRatio(),
+      gfx.height * gfx.renderer.getPixelRatio(),
       {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
@@ -563,16 +563,16 @@ Miew.prototype._initGfx = function () {
   }
 
   gfx.stereoBufL = new THREE.WebGLRenderTarget(
-    gfx.width * window.devicePixelRatio,
-    gfx.height * window.devicePixelRatio,
+    gfx.width * gfx.renderer.getPixelRatio(),
+    gfx.height * gfx.renderer.getPixelRatio(),
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
   );
 
   gfx.stereoBufR = new THREE.WebGLRenderTarget(
-    gfx.width * window.devicePixelRatio,
-    gfx.height * window.devicePixelRatio,
+    gfx.width * gfx.renderer.getPixelRatio(),
+    gfx.height * gfx.renderer.getPixelRatio(),
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
@@ -1072,7 +1072,7 @@ Miew.prototype._renderFrame = (function () {
     }
 
     // resize offscreen buffers to match the target
-    this._resizeOffscreenBuffers(_size.width * window.devicePixelRatio, _size.height * window.devicePixelRatio, stereo);
+    this._resizeOffscreenBuffers(_size.width * gfx.renderer.getPixelRatio(), _size.height * gfx.renderer.getPixelRatio(), stereo);
 
     switch (stereo) {
       case 'WEBVR':
@@ -3065,7 +3065,7 @@ Miew.prototype.screenshot = function (width, height) {
 
   let screenshotURI;
 
-  if (width === gfx.width && height === gfx.height) {
+  if (window.devicePixelRatio === 1 && width === gfx.width && height === gfx.height) {
     // renderer.domElement.toDataURL('image/png') returns flipped image in Safari
     // It hasn't been resolved yet, but getScreenshotSafari()
     // fixes it using an extra canvas.
@@ -3081,6 +3081,7 @@ Miew.prototype.screenshot = function (width, height) {
 
     // set appropriate camera aspect & FOV
     const shotAspect = width / height;
+    gfx.renderer.setPixelRatio(1);
     gfx.camera.aspect = shotAspect;
     gfx.camera.fov = tan2Fov(areaOfInterestTanFov2 / Math.min(shotAspect, 1.0));
     gfx.camera.updateProjectionMatrix();
@@ -3093,6 +3094,7 @@ Miew.prototype.screenshot = function (width, height) {
     screenshotURI = getDataURL();
 
     // restore original camera & canvas proportions
+    gfx.renderer.setPixelRatio(window.devicePixelRatio);
     gfx.camera.aspect = originalAspect;
     gfx.camera.fov = originalFov;
     gfx.camera.updateProjectionMatrix();

--- a/src/Miew.js
+++ b/src/Miew.js
@@ -462,7 +462,9 @@ Miew.prototype._initGfx = function () {
   light12.shadow = new THREE.DirectionalLightShadow();
   light12.shadow.bias = 0.09;
   light12.shadow.radius = settings.now.shadow.radius;
-  const shadowMapSize = Math.max(gfx.width, gfx.height) * gfx.renderer.getPixelRatio();
+
+  const pixelRatio = gfx.renderer.getPixelRatio();
+  const shadowMapSize = Math.max(gfx.width, gfx.height) * pixelRatio;
   light12.shadow.mapSize.width = shadowMapSize;
   light12.shadow.mapSize.height = shadowMapSize;
   light12.target.position.set(0.0, 0.0, 0.0);
@@ -475,10 +477,12 @@ Miew.prototype._initGfx = function () {
 
   // add axes
   gfx.axes = new Axes(gfx.root, gfx.camera);
+  const deviceWidth = gfx.width * pixelRatio;
+  const deviceHeight = gfx.height * pixelRatio;
 
   gfx.offscreenBuf = new THREE.WebGLRenderTarget(
-    gfx.width * gfx.renderer.getPixelRatio(),
-    gfx.height * gfx.renderer.getPixelRatio(),
+    deviceWidth,
+    deviceHeight,
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, depthBuffer: true,
     },
@@ -490,24 +494,24 @@ Miew.prototype._initGfx = function () {
   }
 
   gfx.offscreenBuf2 = new THREE.WebGLRenderTarget(
-    gfx.width * gfx.renderer.getPixelRatio(),
-    gfx.height * gfx.renderer.getPixelRatio(),
+    deviceWidth,
+    deviceHeight,
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
   );
 
   gfx.offscreenBuf3 = new THREE.WebGLRenderTarget(
-    gfx.width * gfx.renderer.getPixelRatio(),
-    gfx.height * gfx.renderer.getPixelRatio(),
+    deviceWidth,
+    deviceHeight,
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
   );
 
   gfx.offscreenBuf4 = new THREE.WebGLRenderTarget(
-    gfx.width * gfx.renderer.getPixelRatio(),
-    gfx.height * gfx.renderer.getPixelRatio(),
+    deviceWidth,
+    deviceHeight,
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
@@ -520,8 +524,8 @@ Miew.prototype._initGfx = function () {
   // use float textures for volume rendering if possible
   if (gfx.renderer.getContext().getExtension('OES_texture_float')) {
     gfx.offscreenBuf5 = new THREE.WebGLRenderTarget(
-      gfx.width * gfx.renderer.getPixelRatio(),
-      gfx.height * gfx.renderer.getPixelRatio(),
+      deviceWidth,
+      deviceHeight,
       {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
@@ -532,8 +536,8 @@ Miew.prototype._initGfx = function () {
     );
 
     gfx.offscreenBuf6 = new THREE.WebGLRenderTarget(
-      gfx.width * gfx.renderer.getPixelRatio(),
-      gfx.height * gfx.renderer.getPixelRatio(),
+      deviceWidth,
+      deviceHeight,
       {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
@@ -544,8 +548,8 @@ Miew.prototype._initGfx = function () {
     );
 
     gfx.offscreenBuf7 = new THREE.WebGLRenderTarget(
-      gfx.width * gfx.renderer.getPixelRatio(),
-      gfx.height * gfx.renderer.getPixelRatio(),
+      deviceWidth,
+      deviceHeight,
       {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
@@ -563,16 +567,16 @@ Miew.prototype._initGfx = function () {
   }
 
   gfx.stereoBufL = new THREE.WebGLRenderTarget(
-    gfx.width * gfx.renderer.getPixelRatio(),
-    gfx.height * gfx.renderer.getPixelRatio(),
+    deviceWidth,
+    deviceHeight,
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
   );
 
   gfx.stereoBufR = new THREE.WebGLRenderTarget(
-    gfx.width * gfx.renderer.getPixelRatio(),
-    gfx.height * gfx.renderer.getPixelRatio(),
+    deviceWidth,
+    deviceHeight,
     {
       minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, depthBuffer: false,
     },
@@ -1072,7 +1076,8 @@ Miew.prototype._renderFrame = (function () {
     }
 
     // resize offscreen buffers to match the target
-    this._resizeOffscreenBuffers(_size.width * gfx.renderer.getPixelRatio(), _size.height * gfx.renderer.getPixelRatio(), stereo);
+    const pixelRatio = gfx.renderer.getPixelRatio();
+    this._resizeOffscreenBuffers(_size.width * pixelRatio, _size.height * pixelRatio, stereo);
 
     switch (stereo) {
       case 'WEBVR':


### PR DESCRIPTION
## Description
The issue was about HI-DPI/Retina devices. The screenshot taken by the internal miew command was different from what was expected. This is due to the fact that the screen buffer size was multiplied by the devicePixelRatio parameter in some functions and then compressed to the requested one. 

The parameter had been set in renderer initialization and never changed later. The solution to the problem was to set the pixel ratio renderer parameter to 1 before rendering frame in screenshot function and then return it the original value. In this case, no unwanted multiplication will occur anywhere.

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.