### PR TITLE
Add outline thickness setting

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -1342,6 +1342,10 @@ Miew.prototype._renderOutline = (function () {
     _outlineMaterial.uniforms.srcTexSize.value.set(srcDepthBuffer.width, srcDepthBuffer.height);
     _outlineMaterial.uniforms.color.value = new THREE.Color(settings.now.outline.color);
     _outlineMaterial.uniforms.threshold.value = settings.now.outline.threshold;
+    _outlineMaterial.uniforms.thickness.value = new THREE.Vector2(
+      settings.now.outline.thickness,
+      settings.now.outline.thickness
+    );
 
     gfx.renderer.setRenderTarget(targetBuffer);
     gfx.renderer.renderScreenQuad(_outlineMaterial);
@@ -3691,7 +3695,7 @@ Miew.prototype._initOnSettingsChanged = function () {
   });
 
   on(['axes', 'fxaa', 'ao',
-    'outline.on', 'outline.color', 'outline.threshold'], () => {
+    'outline.on', 'outline.color', 'outline.threshold', 'outline.thickness'], () => {
     this._needRender = true;
   });
 };

--- a/src/Miew.js
+++ b/src/Miew.js
@@ -1344,7 +1344,7 @@ Miew.prototype._renderOutline = (function () {
     _outlineMaterial.uniforms.threshold.value = settings.now.outline.threshold;
     _outlineMaterial.uniforms.thickness.value = new THREE.Vector2(
       settings.now.outline.thickness,
-      settings.now.outline.thickness
+      settings.now.outline.thickness,
     );
 
     gfx.renderer.setRenderTarget(targetBuffer);

--- a/src/gfx/shaders/Outline.frag
+++ b/src/gfx/shaders/Outline.frag
@@ -2,6 +2,7 @@ precision highp float;
 
 uniform sampler2D srcTex;
 uniform vec2 srcTexSize;
+uniform vec2 thickness;
 varying vec2 vUv;
 
 #ifdef DEPTH_OUTLINE
@@ -12,7 +13,7 @@ varying vec2 vUv;
 
 void main() {
 
-  vec2 pixelSize = vec2(1, 1) / srcTexSize;
+  vec2 pixelSize = thickness / srcTexSize;
 
   #ifdef DEPTH_OUTLINE
     float c00 = texture2D(srcDepthTex, vUv + vec2(-pixelSize.x,-pixelSize.y)).x;

--- a/src/gfx/shaders/OutlineMaterial.js
+++ b/src/gfx/shaders/OutlineMaterial.js
@@ -17,6 +17,7 @@ class OutlineMaterial extends THREE.RawShaderMaterial {
         color: { type: 'v3', value: null },
         threshold: { type: 'f', value: null },
         opacity: { type: 'f', value: 1.0 },
+        thickness: { type: 'v2', value: new THREE.Vector2(1, 1) },
       },
       vertexShader,
       fragmentShader,

--- a/src/settings.js
+++ b/src/settings.js
@@ -773,6 +773,7 @@ const defaults = {
     on: false,
     color: 0x000000,
     threshold: 0.1,
+    thickness: 1,
   },
 
   /**


### PR DESCRIPTION
## Description

This pull requests allows you to adjust the outline thickness through the `outline.thickness` setting.

Attached screenshots demonstrate different thickness settings.

## Type of changes

- New feature (non-breaking change which adds functionality)
  - the default is `1`, the same as it was before, so this shouldn't break anything that already exists

## Checklist
_(Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code)_

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation / The changes do not need docs update.

## Screenshots

![miew-outline-thickness-1](https://user-images.githubusercontent.com/1174413/69101094-b59c9c80-0a2c-11ea-81fd-40cd17d25028.png)
![miew-outline-thickness-2](https://user-images.githubusercontent.com/1174413/69101095-b59c9c80-0a2c-11ea-926b-0cc0af3a2403.png)
![miew-outline-thickness-3](https://user-images.githubusercontent.com/1174413/69101097-b59c9c80-0a2c-11ea-9012-eea22b186f86.png)
![miew-outline-thickness-4](https://user-images.githubusercontent.com/1174413/69101098-b59c9c80-0a2c-11ea-9e5c-3a8c1d0a91a2.png)
