### PR TITLE
Replace onParseDone and onParseError events by parsingFinished

### DIFF
--- a/demo/scripts/ui/Menu.js
+++ b/demo/scripts/ui/Menu.js
@@ -1096,6 +1096,8 @@ Menu.prototype._initMiewEventListeners = function () {
     self._updateInfo(e.data);
     self._fillSourceList();
     self._fillReprList();
+
+    self.presetsPanel.actions.pdb.inputs.refresh(self);
   });
 
   this._viewer.addEventListener('titleChanged', (e) => {
@@ -1108,14 +1110,6 @@ Menu.prototype._initMiewEventListeners = function () {
 
   this._viewer.addEventListener('editModeChanged', (e) => {
     self._enableToolbar(e.data);
-  });
-
-  this._viewer.addEventListener('onParseError', () => {
-    self.presetsPanel.actions.pdb.inputs.refresh(self);
-  });
-
-  this._viewer.addEventListener('onParseDone', () => {
-    self.presetsPanel.actions.pdb.inputs.refresh(self);
   });
 };
 

--- a/examples/sequence.html
+++ b/examples/sequence.html
@@ -57,7 +57,10 @@
         viewer.run();
       }
 
-      viewer.addEventListener('onParseDone', function() {
+      viewer.addEventListener('parsingFinished', function(e) {
+        if (e.error) {
+          return;
+        }
         var div = document.getElementById('chains');
 
         viewer._forEachComplexVisual(function(visual) {

--- a/src/Miew.js
+++ b/src/Miew.js
@@ -2178,12 +2178,6 @@ Miew.prototype._onLoad = function (dataSource, opts) {
     delete this._opts.view;
   }
 
-  if (opts.error) {
-    this.dispatchEvent({ type: 'onParseError', error: opts.error });
-  } else {
-    this.dispatchEvent({ type: 'onParseDone' });
-  }
-
   this._refreshTitle();
 
   return visualName;

--- a/src/Miew.js
+++ b/src/Miew.js
@@ -2178,6 +2178,14 @@ Miew.prototype._onLoad = function (dataSource, opts) {
     delete this._opts.view;
   }
 
+  if (opts.error) {
+    // deprecated event since version 0.8.6
+    this.dispatchEvent({ type: 'onParseError', error: opts.error });
+  } else {
+    // deprecated event since version 0.8.6
+    this.dispatchEvent({ type: 'onParseDone' });
+  }
+
   this._refreshTitle();
 
   return visualName;


### PR DESCRIPTION
## Description
Replace onParseDone and onParseError events usage by parsingFinished event

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
