### PR TITLE
Fix possibility of setting unsupported effects

### DIFF
--- a/src/Miew.js
+++ b/src/Miew.js
@@ -396,6 +396,10 @@ Miew.prototype._requestAnimationFrame = function (callback) {
   requestAnimationFrame(callback);
 };
 
+function arezSpritesSupported(context) {
+  return context.getExtension('EXT_frag_depth');
+}
+
 function isAOSupported(context) {
   return (context.getExtension('WEBGL_depth_texture')
   && context.getExtension('WEBGL_draw_buffers'));
@@ -424,7 +428,7 @@ Miew.prototype._initGfx = function () {
   capabilities.init(gfx.renderer);
 
   // z-sprites and ambient occlusion possibility
-  if (!gfx.renderer.getContext().getExtension('EXT_frag_depth')) {
+  if (!arezSpritesSupported(gfx.renderer.getContext())) {
     settings.set('zSprites', false);
   }
   if (isAOSupported(gfx.renderer.getContext())) {
@@ -3698,6 +3702,13 @@ Miew.prototype._initOnSettingsChanged = function () {
     } else {
       const values = { normalsToGBuffer: settings.now.ao };
       this._setUberMaterialValues(values);
+    }
+  });
+
+  on('zSprites', () => {
+    if (settings.now.zSprites && !arezSpritesSupported(this._gfx.renderer.getContext())) {
+      this.logger.warn('Your device or browser does not support zSprites');
+      settings.set('zSprites', false);
     }
   });
 


### PR DESCRIPTION
## Description
Fix
- It is possible to set zSprites=true when the hardware doesn't support them
- Ambient occlusion breaks in IE11

## Type of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
