### PR TITLE
Add volume maps upload from keyword and id

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "coveralls": "^3.1.0",
     "lcov-result-merger": "^3.1.0",
     "lerna": "^3.21.0"
+  },
+  "dependencies": {
+    "pako": "^1.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,5 @@
     "coveralls": "^3.1.0",
     "lcov-result-merger": "^3.1.0",
     "lerna": "^3.21.0"
-  },
-  "dependencies": {
-    "pako": "^1.0.11"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -143,6 +143,7 @@
     "npm-run-all": "^4.1.3",
     "nyc": "^15.0.0",
     "open": "^7.0.3",
+    "pako": "^1.0.11",
     "postcss-advanced-variables": "^3.0.1",
     "postcss-calc": "^7.0.2",
     "postcss-cli": "^7.1.1",

--- a/packages/lib/src/Miew.js
+++ b/packages/lib/src/Miew.js
@@ -55,6 +55,7 @@ const EDIT_MODE = { COMPLEX: 0, COMPONENT: 1, FRAGMENT: 2 };
 
 const LOADER_NOT_FOUND = 'Could not find suitable loader for this source';
 const PARSER_NOT_FOUND = 'Could not find suitable parser for this source';
+const OPERATION_CANCELED = 'Operation cancelled';
 
 const { createElement } = utils;
 
@@ -1908,7 +1909,7 @@ function _saveLoadOptions(opts) {
 function _fetchData(sources, opts, job) {
   return new Promise(((resolve) => {
     if (job.shouldCancel()) {
-      throw new Error('Operation cancelled');
+      throw new Error(OPERATION_CANCELED);
     }
     job.notify({ type: 'fetching' });
 
@@ -1977,7 +1978,7 @@ function _fetchData(sources, opts, job) {
 
 function _decompressData(data, opts, job) {
   if (job.shouldCancel()) {
-    return Promise.reject(new Error('Operation cancelled'));
+    return Promise.reject(new Error(OPERATION_CANCELED));
   }
 
   return new Promise((resolve) => {
@@ -1993,7 +1994,7 @@ function _decompressData(data, opts, job) {
 
 function _parseData(data, opts, job) {
   if (job.shouldCancel()) {
-    return Promise.reject(new Error('Operation cancelled'));
+    return Promise.reject(new Error(OPERATION_CANCELED));
   }
 
   job.notify({ type: 'parsing' });

--- a/packages/lib/src/Miew.js
+++ b/packages/lib/src/Miew.js
@@ -1813,7 +1813,7 @@ function updateBinaryMode(opts) {
   let { binary } = opts;
 
   // detect by format
-  if (binary === undefined && opts.fileType !== undefined) {
+  if (opts.fileType !== undefined) {
     const TheParser = _.head(io.parsers.find({ format: opts.fileType }));
     if (TheParser) {
       binary = TheParser.binary || false;

--- a/packages/lib/src/Miew.js
+++ b/packages/lib/src/Miew.js
@@ -1736,12 +1736,13 @@ Miew.prototype._export = function (format) {
   return Promise.reject(new Error('Unexpected format of data'));
 };
 
-function _resolveShortcutId(source, opts, matchesId) {
+function _resolveShortcutId(opts, matchesId) {
   let [, format = 'pdb', id] = matchesId;
 
   format = format.toLowerCase();
   id = id.toUpperCase();
   let compressType = '';
+  let source = '';
 
   switch (format) {
     case 'pdb':
@@ -1773,9 +1774,9 @@ function _resolveShortcutId(source, opts, matchesId) {
   return source;
 }
 
-function _resolveShortcutPubchem(source, opts, matchesPubchem) {
+function _resolveShortcutPubchem(opts, matchesPubchem) {
   const compound = matchesPubchem[1].toLowerCase();
-  source = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/${compound}/JSON?record_type=3d`;
+  const source = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/${compound}/JSON?record_type=3d`;
   opts.fileType = 'pubchem';
   opts.fileName = `${compound}.json`;
   opts.sourceType = 'url';
@@ -1795,13 +1796,13 @@ function _resolveSourceShortcut(source, opts) {
   // e.g. "mmtf:1CRN"
   const matchesId = rePdbId.exec(source) || reMapId.exec(source);
   if (matchesId) {
-    return _resolveShortcutId(source, opts, matchesId);
+    return _resolveShortcutId(opts, matchesId);
   }
 
   // e.g. "pc:aspirin"
   const matchesPubchem = rePubchem.exec(source);
   if (matchesPubchem) {
-    return _resolveShortcutPubchem(source, opts, matchesPubchem);
+    return _resolveShortcutPubchem(opts, matchesPubchem);
   }
 
   // otherwise is should be an URL

--- a/packages/lib/src/Miew.js
+++ b/packages/lib/src/Miew.js
@@ -1905,6 +1905,16 @@ function _saveLoadOptions(opts) {
     }
   }
 }
+function _fetchingErrorCallback(error, opts, job) {
+  console.timeEnd('fetch');
+  opts.context.logger.debug(error.message);
+  if (error.stack) {
+    opts.context.logger.debug(error.stack);
+  }
+  opts.context.logger.error('Fetching failed');
+  job.notify({ type: 'fetchingDone', error });
+  throw error;
+}
 
 function _fetchData(sources, opts, job) {
   return new Promise(((resolve) => {
@@ -1961,16 +1971,7 @@ function _fetchData(sources, opts, job) {
         job.notify({ type: 'fetchingDone', data });
         return data;
       })
-      .catch((error) => {
-        console.timeEnd('fetch');
-        opts.context.logger.debug(error.message);
-        if (error.stack) {
-          opts.context.logger.debug(error.stack);
-        }
-        opts.context.logger.error('Fetching failed');
-        job.notify({ type: 'fetchingDone', error });
-        throw error;
-      });
+      .catch((error) => _fetchingErrorCallback(error, opts, job));
 
     resolve(fetchPromise);
   }));

--- a/packages/lib/src/Miew.js
+++ b/packages/lib/src/Miew.js
@@ -1885,6 +1885,26 @@ function _clarifyMultiFormat(source) {
   });
 }
 
+function _saveLoadOptions(opts) {
+  // FIXME: All new settings retrieved from server are applied after the loading is complete. However, we need some
+  // flags to alter the loading process itself. Here we apply them in advance. Dirty hack. Kill the server, remove
+  // all hacks and everybody's happy.
+  let newOptions = _.get(opts, 'preset.expression');
+  if (!_.isUndefined(newOptions)) {
+    newOptions = JSON.parse(newOptions);
+    if (newOptions && newOptions.settings) {
+      const keys = ['singleUnit'];
+      for (let keyIndex = 0, keyCount = keys.length; keyIndex < keyCount; ++keyIndex) {
+        const key = keys[keyIndex];
+        const value = _.get(newOptions.settings, key);
+        if (!_.isUndefined(value)) {
+          settings.set(key, value);
+        }
+      }
+    }
+  }
+}
+
 function _fetchData(sources, opts, job) {
   return new Promise(((resolve) => {
     if (job.shouldCancel()) {
@@ -1915,23 +1935,7 @@ function _fetchData(sources, opts, job) {
         // should it be text or binary?
         updateBinaryMode(opts);
 
-        // FIXME: All new settings retrieved from server are applied after the loading is complete. However, we need some
-        // flags to alter the loading process itself. Here we apply them in advance. Dirty hack. Kill the server, remove
-        // all hacks and everybody's happy.
-        let newOptions = _.get(opts, 'preset.expression');
-        if (!_.isUndefined(newOptions)) {
-          newOptions = JSON.parse(newOptions);
-          if (newOptions && newOptions.settings) {
-            const keys = ['singleUnit'];
-            for (let keyIndex = 0, keyCount = keys.length; keyIndex < keyCount; ++keyIndex) {
-              const key = keys[keyIndex];
-              const value = _.get(newOptions.settings, key);
-              if (!_.isUndefined(value)) {
-                settings.set(key, value);
-              }
-            }
-          }
-        }
+        _saveLoadOptions(opts);
 
         // create a loader
         const loader = new TheLoader(source, opts);

--- a/packages/lib/src/io/loaders/FileLoader.js
+++ b/packages/lib/src/io/loaders/FileLoader.js
@@ -5,7 +5,7 @@ export default class FileLoader extends Loader {
     super(source, options);
 
     options = this._options;
-    this._binary = options.binary === true;
+    this._binary = (options.binary === true || options.compressType !== '');
   }
 
   load() {

--- a/packages/lib/src/io/loaders/FileLoader.js
+++ b/packages/lib/src/io/loaders/FileLoader.js
@@ -1,13 +1,6 @@
 import Loader from './Loader';
 
 export default class FileLoader extends Loader {
-  constructor(source, options) {
-    super(source, options);
-
-    options = this._options;
-    this._binary = (options.binary === true || options.compressType !== '');
-  }
-
   load() {
     return new Promise((resolve, reject) => {
       if (this._abort) {

--- a/packages/lib/src/io/loaders/FileLoader.test.js
+++ b/packages/lib/src/io/loaders/FileLoader.test.js
@@ -44,6 +44,11 @@ describe('FileLoader', () => {
       return buf;
     })();
 
+    const fakeOptsString = {
+      binary: false,
+      compressType: '',
+    };
+
     let loader;
     let fileReaderStub;
 
@@ -100,7 +105,7 @@ describe('FileLoader', () => {
         },
       };
       global.FileReader = sinon.stub().returns(fileReaderStub);
-      loader = new FileLoader(fakeSource);
+      loader = new FileLoader(fakeSource, fakeOptsString);
     });
 
     afterEach(() => {

--- a/packages/lib/src/io/loaders/Loader.js
+++ b/packages/lib/src/io/loaders/Loader.js
@@ -6,6 +6,7 @@ export default class Loader extends EventDispatcher {
     super();
     this._source = source;
     this._options = options || {};
+    this._binary = (options.binary === true || options.compressType !== '');
     this._abort = false;
     this._agent = null;
   }

--- a/packages/lib/src/io/loaders/Loader.js
+++ b/packages/lib/src/io/loaders/Loader.js
@@ -6,9 +6,13 @@ export default class Loader extends EventDispatcher {
     super();
     this._source = source;
     this._options = options || {};
-    this._binary = (options.binary === true || options.compressType !== '');
     this._abort = false;
     this._agent = null;
+
+    this._binary = false;
+    if (options) {
+      this._binary = (options.binary === true || options.compressType !== '');
+    }
   }
 
   load() {

--- a/packages/lib/src/io/loaders/XHRLoader.js
+++ b/packages/lib/src/io/loaders/XHRLoader.js
@@ -5,13 +5,6 @@ import Loader from './Loader';
 const urlStartRegexp = /^(https?|ftp):\/\//i;
 
 export default class XHRLoader extends Loader {
-  constructor(source, options) {
-    super(source, options);
-
-    options = this._options;
-    this._binary = (options.binary === true || options.compressType !== '');
-  }
-
   load() {
     return new Promise((resolve, reject) => {
       if (this._abort) {

--- a/packages/lib/src/io/loaders/XHRLoader.js
+++ b/packages/lib/src/io/loaders/XHRLoader.js
@@ -9,7 +9,7 @@ export default class XHRLoader extends Loader {
     super(source, options);
 
     options = this._options;
-    this._binary = (options.binary === true);
+    this._binary = (options.binary === true || options.compressType !== '');
   }
 
   load() {

--- a/packages/lib/src/io/loaders/XHRLoader.test.js
+++ b/packages/lib/src/io/loaders/XHRLoader.test.js
@@ -26,6 +26,11 @@ describe('XHRLoader', () => {
       return buf;
     })();
 
+    const fakeOptsString = {
+      binary: false,
+      compressType: '',
+    };
+
     let loader;
     let xhrStub;
     let OldXMLHttpRequest;
@@ -89,7 +94,7 @@ describe('XHRLoader', () => {
       };
       OldXMLHttpRequest = global.XMLHttpRequest;
       global.XMLHttpRequest = sinon.stub().returns(xhrStub);
-      loader = new XHRLoader(fakeSource);
+      loader = new XHRLoader(fakeSource, fakeOptsString);
     });
 
     afterEach(() => {

--- a/packages/lib/src/io/parsers/CCP4Parser.js
+++ b/packages/lib/src/io/parsers/CCP4Parser.js
@@ -145,7 +145,7 @@ class CCP4Parser extends Parser {
   }
 }
 
-CCP4Parser.formats = ['ccp4'];
+CCP4Parser.formats = ['ccp4', 'map'];
 CCP4Parser.extensions = ['.ccp4', '.map', '.mrc'];
 CCP4Parser.binary = true;
 

--- a/packages/lib/src/utils.js
+++ b/packages/lib/src/utils.js
@@ -383,9 +383,9 @@ function getFileExtension(fileName) {
 }
 
 function splitFileName(fileName) {
-  const ext = getFileExtension(fileName);
-  const name = fileName.slice(0, fileName.length - ext.length);
-  return [name, ext];
+  const reNameExtCompress = /^([\w-]+)(?:(\.pdb|\.cif|\.mmtf|\.ccp4|\.dsn6|\.map))\.?(?:(gz))?$/i;
+  const matchName = reNameExtCompress.exec(fileName);
+  return [matchName[1], matchName[2], matchName[3] || ''];
 }
 
 function dataUrlToBlob(url) {

--- a/packages/lib/src/utils.js
+++ b/packages/lib/src/utils.js
@@ -523,6 +523,29 @@ function mergeTypedArraysUnsafe(array) {
   return result;
 }
 
+function getEmdFromPdbId(pdbID) {
+  return new Promise((resolve) => {
+    const request = new XMLHttpRequest();
+    request.addEventListener('load', () => {
+      if (request.status === 200) {
+        const headerFile = request.response;
+        const indEmd = headerFile.indexOf('EMD-');
+        if (indEmd !== -1) {
+          const strEmd = headerFile.substring(indEmd + 4, indEmd + 10);
+          const expNumber = /\d+/g;
+          resolve(expNumber.exec(strEmd)[0]);
+        }
+      }
+      resolve(null);
+    });
+
+    const url = `https://files.rcsb.org/header/${pdbID}.pdb`;
+    request.open('GET', url);
+    request.responseType = 'text';
+    request.send();
+  });
+}
+
 //----------------------------------------------------------------------------
 // Exports
 
@@ -561,4 +584,5 @@ export default {
   download,
   concatTypedArraysUnsafe,
   mergeTypedArraysUnsafe,
+  getEmdFromPdbId,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10224,7 +10224,7 @@ package-hash@^4.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
-pako@^1.0.11:
+pako@^1.0.11, pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10224,7 +10224,7 @@ package-hash@^4.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
-pako@~1.0.2, pako@~1.0.5:
+pako@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==


### PR DESCRIPTION
## Description

New features:
1. Upload (.map)s from EMD databank with EMD id and keyword "map", for example: "map: 2222"
2. Upload any volume map (.dsn6 or .map) with pdb id, if such exists; keywords "v" or "volume", for example: "volume: 3jck"
3. Upload files in .gz (compressed) format

## Type of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
