### PR TITLE
Fix the crash while displaying volumetric data

### DIFF
--- a/packages/miew/src/gfx/shaders/UberMaterial.js
+++ b/packages/miew/src/gfx/shaders/UberMaterial.js
@@ -131,7 +131,7 @@ const uberOptions = {
 
 class UberMaterial extends RawShaderMaterial {
   constructor(params) {
-    super(params)
+    super()
     // add fog
     this.fog = true
     // used for instanced geometry
@@ -178,17 +178,19 @@ class UberMaterial extends RawShaderMaterial {
     this.normalsToGBuffer = false
     // used for toon material
     this.toonShading = false
-    this.uberOptions = uberOptions
+    // uber options of "root" materials are inherited from single uber-options object that resides in prototype
+    this.uberOptions = Object.create(uberOptions)
     // set default values
-    this.setValues({
+    super.setValues({
       uniforms: UniformsUtils.clone(defaultUniforms),
       vertexShader: this.precisionString() + vertexShader,
       fragmentShader: this.precisionString() + fragmentShader,
       lights: true,
       fog: true,
-      side: DoubleSide,
-      ...params
+      side: DoubleSide
     })
+
+    this.setValues(params)
   }
 
   precisionString() {
@@ -238,6 +240,7 @@ class UberMaterial extends RawShaderMaterial {
     return this
   }
 
+  // create copy of this material
   // its options are prototyped after this material's options
   createInstance() {
     const inst = new UberMaterial()
@@ -383,5 +386,7 @@ class UberMaterial extends RawShaderMaterial {
     })
   }
 }
+
+UberMaterial.prototype.uberOptions = uberOptions
 
 export default UberMaterial


### PR DESCRIPTION
## Description

Fixes #417

Revert (inadvertent?) changes to UberMaterial added in ba59b112df0a6ae0d8ce2c5de214d2499f3063f7 (#342, #344).
We can introduce some of them back after thorough consideration.

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation / The changes do not need docs update.
