### PR TITLE
Update and simplify docs on embedding miew

### DIFF
--- a/packages/lib/docs/tutorials/embed.md
+++ b/packages/lib/docs/tutorials/embed.md
@@ -31,20 +31,19 @@ _index.html_
   <meta charset="UTF-8">
   <title>Miew via Global</title>
   
-  <link rel="stylesheet" href="Miew.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/miew@0.9.0/dist/Miew.min.css">
   <script src="https://unpkg.com/@babel/polyfill@7/dist/polyfill.min.js"></script>
-  <script src="Miew.min.js"></script>
+  <script src="https://unpkg.com/lodash@4.17.15/lodash.js"></script>
+  <script src="https://unpkg.com/three@0.112.1/build/three.min.js"></script>
+  <script src="https://unpkg.com/miew@0.9.0/dist/Miew.min.js"></script>
 </head>
 <body>
+  <h1>Use Miew via browser globals</h1>
   <div class="miew-container" style="width:640px; height:480px"></div>
 
   <script>
     (function() {
-      var viewer = new Miew({
-        container: document.getElementsByClassName('miew-container')[0],
-        load: '1CRN',
-      });
-
+      var viewer = new Miew({ load: '1CRN' });
       if (viewer.init()) {
         viewer.run();
       }
@@ -65,20 +64,23 @@ _index.html_
   <meta charset="UTF-8">
   <title>Miew via Require.js</title>
 
-  <link rel="stylesheet" href="Miew.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/miew@0.9.0/dist/Miew.min.css">
   <script src="https://unpkg.com/@babel/polyfill@7/dist/polyfill.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"></script>
 </head>
 <body>
+  <h1>Use Miew via Require.js</h1>
   <div class="miew-container" style="width:640px; height:480px"></div>
 
   <script>
-    require(['Miew.min'], function(Miew) {
-      var viewer = new Miew({
-        container: document.getElementsByClassName('miew-container')[0],
-        load: '1CRN',
-      });
-
+    require.config({
+      paths: {
+        'lodash': 'https://unpkg.com/lodash@^4.17.15/lodash',
+        'three': 'https://unpkg.com/three@0.112.0/build/three.min',
+      }
+    });
+    require(['https://unpkg.com/miew@0.9.0/dist/Miew.min.js'], function(Miew) {
+      var viewer = new Miew({ load: '1CRN' });
       if (viewer.init()) {
         viewer.run();
       }
@@ -88,13 +90,23 @@ _index.html_
 </html>
 ```
 
-## Node.js
+## Node.js Limited Support
 
 _index.js_
 
 ```js
 var Miew = require('miew');
 console.log(Miew.VERSION);
+```
+
+_package.json_
+
+```json
+{
+  "dependencies": {
+    "miew": "0.9.0"
+  }
+}
 ```
 
 ## Browserify
@@ -108,11 +120,12 @@ _index.html_
   <meta charset="UTF-8">
   <title>Miew via Browserify</title>
 
-  <link rel="stylesheet" href="Miew.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/miew@0.9.0/dist/Miew.min.css">
   <script src="https://unpkg.com/@babel/polyfill@7/dist/polyfill.min.js"></script>
   <script src="bundle.js"></script>
 </head>
 <body>
+  <h1>Use Miew via Browserify</h1>
   <div class="miew-container" style="width:640px; height:480px"></div>
 </body>
 </html>
@@ -123,16 +136,22 @@ _index.js_
 ```js
 var Miew = require('miew');
 
-window.onload = function() {
-  var viewer = new Miew({
-    container: document.getElementsByClassName('miew-container')[0],
-    load: '1CRN',
-  });
-
+window.onload = function () {
+  var viewer = new Miew({ load: '1CRN' });
   if (viewer.init()) {
     viewer.run();
   }
 };
+```
+
+_package.json_
+
+```json
+{
+  "dependencies": {
+    "miew": "0.9.0"
+  }
+}
 ```
 
 ## Webpack
@@ -145,10 +164,12 @@ _index.html_
 <head>
   <meta charset="UTF-8">
   <title>Miew via Webpack</title>
+
   <script src="https://unpkg.com/@babel/polyfill@7/dist/polyfill.min.js"></script>
-  <script src="bundle.js"></script>
+  <script src="dist/main.js"></script>
 </head>
 <body>
+  <h1>Use Miew via Webpack</h1>
   <div class="miew-container" style="width:640px; height:480px"></div>
 </body>
 </html>
@@ -157,20 +178,21 @@ _index.html_
 _index.js_
 
 ```js
-require('Miew.min.css');
+import Miew from 'miew';
+import './index.css';
 
-var Miew = require('miew');
-
-window.onload = function() {
-  var viewer = new Miew({
-    container: document.getElementsByClassName('miew-container')[0],
-    load: '1CRN',
-  });
-
+window.onload = function () {
+  var viewer = new Miew({ load: '1CRN' });
   if (viewer.init()) {
     viewer.run();
   }
 };
+```
+
+_index.css_
+
+```css
+@import "miew";
 ```
 
 _webpack.config.js_
@@ -178,9 +200,6 @@ _webpack.config.js_
 ```js
 module.exports = {
   entry: './index.js',
-  output: {
-    filename: 'bundle.js'
-  },
   module: {
     rules: [{
       test: /\.css$/,
@@ -188,4 +207,18 @@ module.exports = {
     }],
   },
 };
+```
+
+_package.json_
+
+```json
+{
+  "dependencies": {
+    "css-loader": "6.8.1",
+    "miew": "0.9.0",
+    "style-loader": "3.3.3",
+    "webpack": "5.88.2",
+    "webpack-cli": "5.1.4"
+  }
+}
 ```


### PR DESCRIPTION
## Description

A part of #449: fix the outdated instructions on embedding miew in your application using different frameworks. Also, pins the miew version to 0.9.0 for reproducible behavior.

The extraneous startup option `container` is removed to simplify the examples.

## Type of changes

- Documentation fix

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works. - **Not applicable**
- [x] I have added the necessary documentation / The changes do not need docs update.
