### PR TITLE
Color residue names in the "sequence" example

### DIFF
--- a/packages/lib/examples/sequence.html
+++ b/packages/lib/examples/sequence.html
@@ -25,6 +25,7 @@
       color: black;
       text-decoration: none;
       font-family: monospace;
+      border-bottom: 2px solid black;
     }
 
     .sequence {
@@ -67,9 +68,10 @@
 
         viewer._forEachComplexVisual(function(visual) {
           var complex = visual.getComplex();
+          var colorer = visual.repGet().colorer;
           var chains = complex.getChainNames();
           for (var i = 0; i < chains.length; ++i) {
-            var elem = createChainElement(complex.getChain(chains[i]));
+            var elem = createChainElement(complex.getChain(chains[i]), colorer);
             div.appendChild(elem);
           }
         });
@@ -128,7 +130,7 @@
         });
       });
 
-      function createChainElement(chain) {
+      function createChainElement(chain, colorer) {
         var elem = document.createElement('div');
 
         // show chain name
@@ -147,10 +149,14 @@
           // skip water
           if (resType.flags & Miew.chem.ResidueType.Flags.WATER) return;
 
+          // assign color
+          var color = colorer.getResidueColor(res, chain._complex);
+
           // create residue a-element
           var resElem = document.createElement('a');
           resElem.id = String(res._index);
           resElem.textContent = resType.letterCode;
+          resElem.style.borderColor = '#' + color.toString(16).padStart(6, '0');
           resElem.href = '#';
           resElem.dataset.residx = res._index;
           resDiv.appendChild(resElem);


### PR DESCRIPTION
## Description

Closes #454

Add a colored border at the bottom of each residue name. The change demonstrates how to access representation parameters (and the Colorer in particular). For the sake of simplicity, only the current Representation is used for all residues. A more correct implementation should iterate over all representations and test if the residue belongs to the corresponding Selector.

![shot-20230906-134824-scale](https://github.com/epam/miew/assets/11373544/98f05ad0-9b76-4678-91bd-68525c57a964)

## Type of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works. --- **N/A**
- [x] I have added necessary documentation / The changes do not need docs update.
