### PR TITLE
Remove outdated badges and add basic ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,10 @@
 > This is the new "main" branch for further development 🚀 
 
 
-[![Linux Build Status](https://img.shields.io/travis/epam/miew/master.svg?label=linux)](https://travis-ci.org/epam/miew)
-[![Windows Build Status](https://img.shields.io/appveyor/ci/paulsmirnov/miew/master.svg?label=windows)](https://ci.appveyor.com/project/paulsmirnov/miew/branch/master)
-[![Snyk badge](https://snyk.io/test/github/epam/miew/badge.svg)](https://snyk.io/test/github/epam/miew)
-[![Coverage Status](https://coveralls.io/repos/github/epam/miew/badge.svg)](https://coveralls.io/github/epam/miew)
-<br>
-[![Code Climate](https://codeclimate.com/github/epam/miew/badges/gpa.svg)](https://codeclimate.com/github/epam/miew)
-[![SonarCloud Maintainability](https://sonarcloud.io/api/project_badges/measure?project=epam:miew&metric=sqale_rating)](https://sonarcloud.io/component_measures?id=epam:miew&metric=Maintainability)
-[![SonarCloud Reliability](https://sonarcloud.io/api/project_badges/measure?project=epam:miew&metric=reliability_rating)](https://sonarcloud.io/component_measures?id=epam:miew&metric=Reliability)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=epam:miew&metric=alert_status)](https://sonarcloud.io/dashboard?id=epam:miew)
+[![Build Status](https://img.shields.io/appveyor/ci/paulsmirnov/miew/main.svg)](https://ci.appveyor.com/project/paulsmirnov/miew/branch/main)
+[![Version](https://img.shields.io/npm/v/miew)](https://www.npmjs.com/package/miew?activeTab=versions)
+[![Downloads](https://img.shields.io/npm/dm/miew)](https://www.npmjs.com/package/miew?activeTab=versions)
+[![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE.md)
 
 Copyright (c) 2015–2023 [EPAM Systems, Inc.](https://www.epam.com/)
 


### PR DESCRIPTION
## Description

I noticed that our build status badge points to the "master" branch while we are using the "main" branch instead. Other badges don't work because corresponding integrations are disabled. I fixed the branch reference, removed non-working badges, and added a couple of basic badges that make sense (npm version, downloads counter, and license).

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes **/ Not applicable**
- [x] I have added tests that prove my fix is effective or that my feature works **/ Not applicable**
- [x] I have added necessary documentation **/ Not applicable**
