### PR TITLE
Clarify the GitHub PR Template we use

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,17 +9,18 @@ _(Provide a clear and concise description of what the changes are)_
 _(Please [add screenshots](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/) if appropriate)_
 
 ## Type of changes
-_(Leave only items that apply)_
+_(Keep only the item(s) that apply)_
 
-- Bug fix (non-breaking change which fixes an issue)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Dependency update (non-breaking change that updates third-party packages)
+- Bug fix (non-breaking change that fixes an issue)
+- New feature (non-breaking change that adds functionality)
+- Breaking change (fix or feature that would cause existing functionality not to work as expected)
 
 ## Checklist
-_(Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code)_
+_(Put an `x` in the boxes that apply---ideally, all five. If you're unsure about any of them, don't hesitate to ask. We're here to help!)_
 
 - [ ] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
 - [ ] I have followed the code style of this project.
 - [ ] I have run `yarn run ci`: lint and tests pass locally with my changes.
-- [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] I have added necessary documentation / The changes do not need docs update.
+- [ ] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
+- [ ] I have added the necessary documentation _OR_ The changes do not require updated docs.


### PR DESCRIPTION
Changed the wording in the template to cover more cases and encourage toggling all five checkboxes.