### PR TITLE
Remove css dependency from lib

### DIFF
--- a/packages/app/src/components/App.jsx
+++ b/packages/app/src/components/App.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Menu from '../containers/MenuContainer';
 import Viewer from '../containers/MiewViewerContainer';
 import './App.scss';
+
 export default class App extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/app/src/components/App.jsx
+++ b/packages/app/src/components/App.jsx
@@ -3,10 +3,6 @@ import React from 'react';
 import Menu from '../containers/MenuContainer';
 import Viewer from '../containers/MiewViewerContainer';
 import './App.scss';
-// Need to fix this because the demo will be removed. We should not depend on anything there.
-// eslint-disable-next-line import/no-relative-packages
-import '../../../lib/demo/styles/main.scss';
-
 export default class App extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
Removed code dependency. #487 
The CSS import isn't needed anymore.

note: I didn't find any other dependencies in the code.

## Type of changes
- Dependency update (non-breaking change that updates third-party packages)

## Checklist
_(Put an `x` in the boxes that apply---ideally, all five. If you're unsure about any of them, don't hesitate to ask. We're here to help!)_

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
