### PR TITLE
Fix test:e2e script for 'lib' package

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,7 +24,7 @@
     "test": "run-s test:unit",
     "test-cover": "cross-env NODE_ENV=coverage nyc mocha",
     "test:unit": "mocha",
-    "test:e2e": "rimraf './test/e2e/mismatch/*.png' './test/e2e/mismatch/report-*.html' && mocha --config ./test/.e2e.mocharc.js",
+    "test:e2e": "rimraf --glob './test/e2e/mismatch/*.png' './test/e2e/mismatch/report-*.html' && mocha --config ./test/.e2e.mocharc.js",
     "start": "webpack-dev-server --mode development --open",
     "clean": "rimraf build coverage",
     "build": "run-s 'build:*'",


### PR DESCRIPTION
## Description

- after recent 'rimraf' version update accepted path format changed. now we have to use '--glob' for paths containing wildcard. 

## Type of changes
- Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
