### PR TITLE
Update to actions/setup-node@v4 as previous one is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
         cache: 'yarn'


### PR DESCRIPTION
## Description

Update to actions/setup-node@v4 as previous one is deprecated.

The warning was 
![image](https://github.com/epam/miew/assets/25740843/50bb6865-b467-4683-b91d-ba5cd39c4cd8)

## Type of changes
- Dependency update (non-breaking change that updates third-party packages)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
