### PR TITLE
Fix Panel opening after Serotonin loading

### DIFF
--- a/packages/app/src/components/menu/panelslist/panels/InfoPanel.jsx
+++ b/packages/app/src/components/menu/panelslist/panels/InfoPanel.jsx
@@ -6,6 +6,8 @@ import './InfoPanel.scss';
 const InfoPanel = ({ complex }) => {
   const { name, metadata } = complex[0];
   const { classification, title, id } = metadata;
+
+  const isTitleProvided = title !== undefined;
   const molecules = complex[0].getMolecules();
 
   const statistics = [
@@ -48,7 +50,7 @@ const InfoPanel = ({ complex }) => {
         {id || name || 'Unknown data'}
         {classification && <small> / {classification}</small>}
       </h1>
-      <p>{title.join(' ')}</p>
+      <p>{isTitleProvided ? title.join(' ') : ''}</p>
       <Table>
         <thead>
           <tr>


### PR DESCRIPTION
## Description

#514 

- Added checking of molecule title provided with metadata
- If there is no title in file metadata we don't try to show it in the panel

## Type of changes
- Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
