### PR TITLE
Use CIF format instead of discontinued MMTF

### DIFF
--- a/packages/miew-app/src/components/menu/panelslist/panels/GalleryPanel.jsx
+++ b/packages/miew-app/src/components/menu/panelslist/panels/GalleryPanel.jsx
@@ -62,7 +62,7 @@ const galleryPanels = [
       </>
     ),
     image: '4TNW',
-    value: 'mmtf:4TNW',
+    value: 'cif:4TNW',
     query: 'p=macro&c=SQ&v=1xQCuQgIrbUHD9arAmmsnPIj8NL/mF6u%2Bx26BPg%3D%3D',
   },
 ];

--- a/packages/miew/demo/menu.html
+++ b/packages/miew/demo/menu.html
@@ -219,7 +219,7 @@
                   <div class="caption text-center">5B40 <small>(11.8k)</small></div>
                 </a>
               </div>
-              <div class="col-xs-6 col-sm-4" data-toggle="preset-pdb" data-value="mmtf:4TNW" data-query="p=macro&c=SQ&v=1xQCuQgIrbUHD9arAmmsnPIj8NL/mF6u%2Bx26BPg%3D%3D">
+              <div class="col-xs-6 col-sm-4" data-toggle="preset-pdb" data-value="cif:4TNW" data-query="p=macro&c=SQ&v=1xQCuQgIrbUHD9arAmmsnPIj8NL/mF6u%2Bx26BPg%3D%3D">
                 <a href="#" class="thumbnail">
                   <img src="images/4TNW.png">
                   <div class="caption text-center">4TNW <small>(30.4k)</small></div>

--- a/packages/miew/docs/Thumbnails.md
+++ b/packages/miew/docs/Thumbnails.md
@@ -28,7 +28,7 @@ If you decide to update the thumbnails, here are the instructions.
 
  1. Use the following URL Query String to see 1AID file from the fixed viewpoint. 
 
-        ?l=mmtf:1AID&r=0&m=VW&s=not+water&c=CF&v=18KeRwuF6IsJGtmPAs%2B8XPZrOGD9xy0I/ku/APQ==&fogFarFactor=0.4&fogNearFactor=0&axes=false&fxaa=false&ao=true
+        ?l=cif:1AID&r=0&m=VW&s=not+water&c=CF&v=18KeRwuF6IsJGtmPAs%2B8XPZrOGD9xy0I/ku/APQ==&fogFarFactor=0.4&fogNearFactor=0&axes=false&fxaa=false&ao=true
 
  2. Select the desired coloring.
  3. Open the terminal window and take a 512 &times; 512 screenshot.
@@ -63,7 +63,7 @@ If you decide to update the thumbnails, here are the instructions.
 
  1. Use the following URL Query String to see Glycine from the fixed viewpoint. 
 
-        ?l=mmtf:1CRN&p=macro&s=sequence+22:34&r=1&s=sequence+2:3&v=1bjwPwW3%2BQsFuFMbA1kUQPpO4Wj8/v1K/zsjhPg%3D%3D&bg.color=0xCCCCCC&axes=false&fog=false
+        ?l=cif:1CRN&p=macro&s=sequence+22:34&r=1&s=sequence+2:3&v=1bjwPwW3%2BQsFuFMbA1kUQPpO4Wj8/v1K/zsjhPg%3D%3D&bg.color=0xCCCCCC&axes=false&fog=false
 
 
  2. Select the desired palette.

--- a/packages/miew/docs/getting-started-for-dummies.md
+++ b/packages/miew/docs/getting-started-for-dummies.md
@@ -130,8 +130,8 @@ is found in more than ten coordinate files, including 1CRN, 1EJG, 3NIR, and so o
 The primary format used in the protein bank is text [PDB][], but it has its 
 limitations in terms of the number of atoms and residues. As a result, it has 
 been replaced by the more verbose [CIF][] and binary 
-[MMTF][]. To load data directly from the bank, Miew supports using the unique 
-identifier (`1CRN`) and a format specifier (`cif:1CRN`, `mmtf:1CRN`).
+[BCIF][]. To load data directly from the bank, Miew supports using the unique 
+identifier (`1CRN`) and a format specifier (`cif:1CRN`, `pdb:1CRN`).
 
 Small molecules can be found in various formats such as [MOL/SDF][], CML, or 
 others. The [PubChem][] site is the primary source for coordinate files of common 
@@ -155,7 +155,7 @@ data types, such as loading 3D geometry in widely used formats.
 [4V88]: https://www.rcsb.org/structure/4v88
 [PDB]: http://www.wwpdb.org/documentation/file-format-content/format33/v3.3.html
 [CIF]: http://mmcif.wwpdb.org/
-[MMTF]: https://mmtf.rcsb.org/
+[BCIF]: https://github.com/molstar/BinaryCIF
 [MOL/SDF]: http://www.wwpdb.org/documentation/file-format-content/format33/v3.3.html
 [PubChem]: https://pubchem.ncbi.nlm.nih.gov/
 [aspirin]: https://pubchem.ncbi.nlm.nih.gov/compound/2244

--- a/packages/miew/docs/tutorials/url.md
+++ b/packages/miew/docs/tutorials/url.md
@@ -94,7 +94,7 @@ Data source:
     You may choose a different file source: [`l=cif:4xn6`], [`l=pubchem:serotonin`].
 
   - **t**, **type** = _typeId_  
-    Specify explicit type of the loaded file: [`t=mmtf&l=http://mmtf.rcsb.org/v1.0/full/4xn6`].  
+    Specify explicit type of the loaded file: [`t=cif&l=https://files.rcsb.org/view/4XN6.cif`].  
     By default, the application determines the data type automatically by the file name (extension) or the
     file source used.
 
@@ -136,7 +136,7 @@ Visual representation:
 [`l=4xn6`]:             https://miew.opensource.epam.com/?l=4xn6
 [`l=cif:4xn6`]:         https://miew.opensource.epam.com/?l=cif:4xn6
 [`l=pubchem:serotonin`]:https://miew.opensource.epam.com/?l=pubchem:serotonin
-[`t=mmtf&l=http://mmtf.rcsb.org/v1.0/full/4xn6`]: https://miew.opensource.epam.com/?t=mmtf&l=http://mmtf.rcsb.org/v1.0/full/4xn6
+[`t=cif&l=https://files.rcsb.org/view/4XN6.cif`]: https://miew.opensource.epam.com/?t=cif&l=https://files.rcsb.org/view/4XN6.cif
 [`l=3s95&u=2`]:         https://miew.opensource.epam.com/?l=3s95&u=2
 [`p=wire`]:             https://miew.opensource.epam.com/?p=wire
 [`s=residue+ALA,CYS`]:  https://miew.opensource.epam.com/?s=residue+ALA,CYS
@@ -149,13 +149,13 @@ Visual representation:
 
 A complex example follows (whitespaces are for better readability):
 
-[l=mmtf:1rx1 &  
+[l=cif:1rx1 &  
 s=not+hetatm & m=CA & c=SS &  
 s=hetatm+and+not+water & m=LC & c=EL &  
 s=sequence+6:7,17:19,43:45,62:64,77,95:99 & m=CS & mt=PL &  
-bg.color=0xCCCCCC](https://miew.opensource.epam.com/?l=mmtf:1rx1&s=not+hetatm&m=CA&c=SS&s=hetatm+and+not+water&m=LC&c=EL&s=sequence+6:7,17:19,43:45,62:64,77,95:99&m=CS&mt=PL&bg.color=0xCCCCCC)
+bg.color=0xCCCCCC](https://miew.opensource.epam.com/?l=cif:1rx1&s=not+hetatm&m=CA&c=SS&s=hetatm+and+not+water&m=LC&c=EL&s=sequence+6:7,17:19,43:45,62:64,77,95:99&m=CS&mt=PL&bg.color=0xCCCCCC)
 
-  - load 1RX1 in mmtf format;
+  - load 1RX1 in cif format;
   - select "`not hetatm`", set Cartoon mode with Secondary Structure coloring;
   - select "`hetatm and not water`", set Licorice mode with coloring by Element;
   - select residues by their sequential numbers, set Contact Surface mode with the previous coloring (by Element)

--- a/packages/miew/examples/api.html
+++ b/packages/miew/examples/api.html
@@ -16,7 +16,7 @@
   <div style="padding-top: 0.5em">
     <button id="rotation">Toggle Rotation</button>
     <button id="axes">Toggle Axes</button>
-    <button id="load-4xn6">Load 4XN6.mmtf</button>
+    <button id="load-4xn6">Load 4XN6.cif</button>
     <button id="licorice">Licorice</button>
     <button id="metallic">Metallic</button>
     <button id="load-2hhb">Load 2HHB + setup</button>

--- a/packages/miew/examples/api.js
+++ b/packages/miew/examples/api.js
@@ -22,7 +22,7 @@
 
   document.getElementById('load-4xn6').addEventListener('click', function () {
     viewer.unload();
-    viewer.load('mmtf:4XN6');
+    viewer.load('cif:4XN6');
   });
 
   document.getElementById('licorice').addEventListener('click', function () {

--- a/packages/miew/examples/events.html
+++ b/packages/miew/examples/events.html
@@ -14,7 +14,7 @@
 <div class="miew-container" style="width:640px; height:480px; position:relative;"></div>
 
 <div style="padding-top: 0.5em">
-  <button id="load-4xn6">Load 4XN6.mmtf</button>
+  <button id="load-4xn6">Load 4XN6.cif</button>
   <button id="load-1crn">Load 1CRN.pdb</button>
   <button id="repAdd">Create new rep from selection</button>
   <input type="checkbox" id="aoChange">

--- a/packages/miew/examples/events.js
+++ b/packages/miew/examples/events.js
@@ -10,7 +10,7 @@
   }
 
   document.getElementById('load-4xn6').addEventListener('click', function () {
-    viewer.load('mmtf:4XN6');
+    viewer.load('cif:4XN6');
   });
 
   document.getElementById('load-1crn').addEventListener('click', function () {

--- a/packages/miew/examples/multiple.html
+++ b/packages/miew/examples/multiple.html
@@ -13,7 +13,7 @@
   <h1 style="text-align: center;">Create multiple viewers on a page</h1>
   <div>
     <div class="miew-container" style="width:512px; height:512px; float:left" data-miew="load=1CRN"></div>
-    <div class="miew-container" style="width:512px; height:512px; float:right" data-miew="load=mmtf:1CRN"></div>
+    <div class="miew-container" style="width:512px; height:512px; float:right" data-miew="load=cif:1CRN"></div>
     <div style="clear: both"></div>
   </div>
 

--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -1751,7 +1751,7 @@ Miew.prototype._export = function (format) {
   return Promise.reject(new Error('Unexpected format of data'));
 };
 
-const rePdbId = /^(?:(pdb|cif|mmtf|ccp4|dsn6):\s*)?(\d[a-z\d]{3})$/i;
+const rePdbId = /^(?:(pdb|cif|ccp4|dsn6):\s*)?(\d[a-z\d]{3})$/i;
 const rePubchem = /^(?:pc|pubchem):\s*([a-z]+)$/i;
 const reUrlScheme = /^([a-z][a-z\d\-+.]*):/i;
 
@@ -1760,7 +1760,7 @@ function resolveSourceShortcut(source, opts) {
     return source;
   }
 
-  // e.g. "mmtf:1CRN"
+  // e.g. "cif:1CRN"
   const matchesPdbId = rePdbId.exec(source);
   if (matchesPdbId) {
     let [, format = 'pdb', id] = matchesPdbId;
@@ -1774,9 +1774,6 @@ function resolveSourceShortcut(source, opts) {
         break;
       case 'cif':
         source = `https://files.rcsb.org/download/${id}.cif`;
-        break;
-      case 'mmtf':
-        source = `https://mmtf.rcsb.org/v1.0/full/${id}`;
         break;
       case 'ccp4':
         source = `https://www.ebi.ac.uk/pdbe/coordinates/files/${id.toLowerCase()}.ccp4`;

--- a/packages/miew/src/options.test.js
+++ b/packages/miew/src/options.test.js
@@ -157,11 +157,11 @@ describe('options', () => {
       options: {
         view: '1+n4pwTVeI8Erh8LAHI6CPW63vD40uzs/Ne4ovg==',
         unit: 1,
-        load: 'mmtf:1crn',
+        load: 'cif:1crn',
       },
-      string: 'l=mmtf:1crn&u=1&v=1%2Bn4pwTVeI8Erh8LAHI6CPW63vD40uzs/Ne4ovg%3D%3D',
+      string: 'l=cif:1crn&u=1&v=1%2Bn4pwTVeI8Erh8LAHI6CPW63vD40uzs/Ne4ovg%3D%3D',
       commands: [
-        'load "mmtf:1crn"',
+        'load "cif:1crn"',
         'unit 1',
         'view 1+n4pwTVeI8Erh8LAHI6CPW63vD40uzs/Ne4ovg==',
       ],

--- a/packages/miew/tools/fetch.py
+++ b/packages/miew/tools/fetch.py
@@ -8,7 +8,6 @@ import gzip
 formats = {
   'pdb':  {'type': '',  'url': 'http://files.rcsb.org/download/%s.pdb.gz', 'postprocess': lambda data: gzip.decompress(data).decode('ascii') },
   'cif':  {'type': '',  'url': 'http://files.rcsb.org/download/%s.cif.gz', 'postprocess': lambda data: gzip.decompress(data).decode('ascii') },
-  'mmtf': {'type': 'b', 'url': 'http://mmtf.rcsb.org/v1.0/full/%s',        'postprocess': lambda data: data },
   'ccp4': {'type': 'b', 'url': 'https://www.ebi.ac.uk/pdbe/coordinates/files/%s.ccp4', 'postprocess': lambda data: data },
   'dsn6': {'type': 'b', 'url': 'https://edmaps.rcsb.org/maps/%s_2fofc.dsn6', 'postprocess': lambda data: data },
   'pubchem': {'type': '', 'url': 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/%s/JSON?record_type=3d', 'postprocess': lambda data: data.decode('ascii'), 'ext': 'json'},


### PR DESCRIPTION
## Description

Resolves #539 

As of July 2, 2024, RCSB PDB no longer serves PDB data in the MMTF compression format. So, this PR:

- Changes the Gallery and examples to use CIF instead of MMTF,
- Removes the "mmtf:" prefix support from the load function,
- Keeps the MMTF file format support for backward compatibility.

## Type of changes

- Bug fix (non-breaking change that fixes an issue)

Note that the external source ceased to work, so we shouldn't mark it as a breaking change even if it removes the old (non-working) functionality.

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have updated tests that prove my fix/feature works.
- [x] I have updated the necessary documentation.
