### PR TITLE
Make it harder to steal character keys from the outer app

### DIFF
--- a/packages/miew/demo/scripts/ui/Menu.js
+++ b/packages/miew/demo/scripts/ui/Menu.js
@@ -923,6 +923,11 @@ Menu.prototype._init = function () {
         }
       }
     }
+    if (!self._terminal.is(':visible')) {
+      if (e.code === 'KeyS') {
+        settings.set('ao', !settings.now.ao);
+      }
+    }
   });
 
   $(`${self._menuId} [data-toggle="panel"]`).on('click', function _setPanel() {

--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -2888,12 +2888,6 @@ Miew.prototype._onKeyDown = function (event) {
         default: break;
       }
       break;
-    case 'S'.charCodeAt(0):
-      event.preventDefault();
-      event.stopPropagation();
-      settings.set('ao', !settings.now.ao);
-      this._needRender = true;
-      break;
     case 107:
       event.preventDefault();
       event.stopPropagation();

--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -2855,58 +2855,68 @@ Miew.prototype._onKeyDown = function (event) {
     return;
   }
 
-  switch (event.keyCode) {
-    case 'C'.charCodeAt(0):
-      if (settings.now.editing) {
+  // editing keys
+  if (settings.now.editing) {
+    switch (event.code) {
+      case 'KeyC':
         this._enterComponentEditMode();
-      }
-      break;
-    case 'F'.charCodeAt(0):
-      if (settings.now.editing) {
+        break;
+      case 'KeyF':
         this._enterFragmentEditMode();
+        break;
+      case 'KeyA':
+        switch (this._editMode) {
+          case EDIT_MODE.COMPONENT:
+            this._applyComponentEdit();
+            break;
+          case EDIT_MODE.FRAGMENT:
+            this._applyFragmentEdit();
+            break;
+          default:
+            break;
+        }
+        break;
+      case 'KeyD':
+        switch (this._editMode) {
+          case EDIT_MODE.COMPONENT:
+            this._discardComponentEdit();
+            break;
+          case EDIT_MODE.FRAGMENT:
+            this._discardFragmentEdit();
+            break;
+          default:
+            break;
+        }
+        break;
+      default:
+    }
+  }
+
+  // other keys
+  switch (event.code) {
+    case 'NumpadAdd':
+      if (event.altKey) {
+        event.preventDefault();
+        event.stopPropagation();
+        this._forEachComplexVisual((visual) => {
+          visual.expandSelection();
+          visual.rebuildSelectionGeometry();
+        });
+        this._updateInfoPanel();
+        this._needRender = true;
       }
       break;
-    case 'A'.charCodeAt(0):
-      switch (this._editMode) {
-        case EDIT_MODE.COMPONENT:
-          this._applyComponentEdit();
-          break;
-        case EDIT_MODE.FRAGMENT:
-          this._applyFragmentEdit();
-          break;
-        default: break;
+    case 'NumpadSubtract':
+      if (event.altKey) {
+        event.preventDefault();
+        event.stopPropagation();
+        this._forEachComplexVisual((visual) => {
+          visual.shrinkSelection();
+          visual.rebuildSelectionGeometry();
+        });
+        this._updateInfoPanel();
+        this._needRender = true;
       }
-      break;
-    case 'D'.charCodeAt(0):
-      switch (this._editMode) {
-        case EDIT_MODE.COMPONENT:
-          this._discardComponentEdit();
-          break;
-        case EDIT_MODE.FRAGMENT:
-          this._discardFragmentEdit();
-          break;
-        default: break;
-      }
-      break;
-    case 107:
-      event.preventDefault();
-      event.stopPropagation();
-      this._forEachComplexVisual((visual) => {
-        visual.expandSelection();
-        visual.rebuildSelectionGeometry();
-      });
-      this._updateInfoPanel();
-      this._needRender = true;
-      break;
-    case 109:
-      event.preventDefault();
-      event.stopPropagation();
-      this._forEachComplexVisual((visual) => {
-        visual.shrinkSelection();
-        visual.rebuildSelectionGeometry();
-      });
-      this._updateInfoPanel();
-      this._needRender = true;
       break;
     default:
   }
@@ -2917,7 +2927,7 @@ Miew.prototype._onKeyUp = function (event) {
     return;
   }
 
-  if (event.keyCode === 'X'.charCodeAt(0)) {
+  if (event.code === 'KeyX') {
     this._extractRepresentation();
   }
 };


### PR DESCRIPTION
## Description

Resolves #534 

- Move "S" key processing to the demo app (nobody needs it in the library),
- Require "Alt" key with numpad Plus/Minus (a kind of a breaking change but not documented and not used a lot),
- Process editing keys only when editing (an additional safety measure),
- Use `event.code` instead of deprecated `keyCode`.

The `Alt+NumPlus`, `Alt+NumMinus` will still be processed in the miew library unless `miew.enableHotKeys(false)` is called. I believe that's enough to solve the issue in most cases.

## Type of changes

- Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] The changes do not require updated tests.
- [x] The changes do not require updated docs.
