### PR TITLE
Access the top window in a safe manner

### DIFF
--- a/packages/miew/demo/scripts/ui/Menu.js
+++ b/packages/miew/demo/scripts/ui/Menu.js
@@ -2039,7 +2039,7 @@ Menu.prototype._onTerminalOff = function () {
 };
 
 Menu.prototype._fixKeyboard = function () {
-  // do IFRAME related hack
+  // do IFRAME related hack // NOTE: embedding the demo is not recommended/supported anymore
   if (window !== window.top) {
     const parentDocument = window.top.document;
     let button = parentDocument.querySelector('button');

--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -43,6 +43,7 @@ import capabilities from './gfx/capabilities';
 import WebVRPoC from './gfx/vr/WebVRPoC';
 import vertexScreenQuadShader from './gfx/shaders/ScreenQuad.vert';
 import fragmentScreenQuadFromDistTex from './gfx/shaders/ScreenQuadFromDistortionTex.frag';
+import getTopWindow from './utils/getTopWindow';
 
 const {
   selectors,
@@ -298,11 +299,12 @@ Miew.prototype.init = function () {
       zIndex: 700,
     });
 
-    window.top.addEventListener('keydown', (event) => {
+    const target = getTopWindow();
+    target.addEventListener('keydown', (event) => {
       self._onKeyDown(event);
     });
 
-    window.top.addEventListener('keyup', (event) => {
+    target.addEventListener('keyup', (event) => {
       self._onKeyUp(event);
     });
 

--- a/packages/miew/src/ui/ObjectControls.js
+++ b/packages/miew/src/ui/ObjectControls.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import Timer from '../Timer';
 import settings from '../settings';
 import EventDispatcher from '../utils/EventDispatcher';
+import getTopWindow from '../utils/getTopWindow';
 
 const VK_LEFT = 37;
 const VK_UP = 38;
@@ -806,7 +807,7 @@ ObjectControls.prototype.keydownup = function (event) {
 };
 
 ObjectControls.prototype.getKeyBindObject = function () {
-  return window.top;
+  return getTopWindow();
 };
 
 ObjectControls.prototype.dispose = function () {

--- a/packages/miew/src/utils/getTopWindow.js
+++ b/packages/miew/src/utils/getTopWindow.js
@@ -1,0 +1,11 @@
+export default function getTopWindow() {
+  // intercept the exception if we have cross-origin iframe
+  try {
+    if (window.top.location.href !== undefined) {
+      return window.top;
+    }
+  } catch (e) {
+    // provide fallback
+  }
+  return window;
+}

--- a/packages/miew/src/utils/getTopWindow.test.js
+++ b/packages/miew/src/utils/getTopWindow.test.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import getTopWindow from './getTopWindow';
+
+describe('utils/getTopWindow()', () => {
+  it('returns top window if no iframe', () => {
+    const window = { location: { href: 'http://example.com' } };
+    window.top = window;
+
+    global.window = window;
+    expect(getTopWindow()).to.equal(window.top);
+    delete global.window;
+  });
+
+  it('returns top window if no cross-origin iframe', () => {
+    const window = { location: { href: 'http://example.com/viewer.html' } };
+    window.top = { location: { href: 'http://example.com/index.html' } };
+
+    global.window = window;
+    expect(getTopWindow()).to.equal(window.top);
+    delete global.window;
+  });
+
+  it('returns window if called inside cross-origin iframe', () => {
+    const window = { location: { href: 'http://example.com:8000' } };
+    window.top = { locationRestricted: { href: 'http://example.com:8001' } };
+
+    global.window = window;
+    expect(getTopWindow()).to.equal(window);
+    delete global.window;
+  });
+});


### PR DESCRIPTION
## Description

Resolves #524 

Fixes Uncaught DOMException: Failed to read a named property 'addEventListener' from 'Window': Blocked a frame with origin "xxx" from accessing a cross-origin frame.

## Type of changes

- Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works.
- [x] The changes do not require updated docs.
