### PR TITLE
Add zoom in/out limitations

### DIFF
--- a/packages/miew/.stylelintrc.js
+++ b/packages/miew/.stylelintrc.js
@@ -7,6 +7,6 @@ module.exports = {
     'alpha-value-notation': 'number',
     'property-no-vendor-prefix': null,
     'declaration-block-no-redundant-longhand-properties': null,
-    'scss/at-import-partial-extension': 'always',
+    'scss/load-partial-extension': 'always',
   },
 };

--- a/packages/miew/src/ui/ObjectControls.js
+++ b/packages/miew/src/ui/ObjectControls.js
@@ -547,6 +547,12 @@ ObjectControls.prototype.scale = function (factor) {
   if (factor <= 0) {
     return;
   }
+
+  // avoid zoom getting lost in space
+  const tooSmall = this.object.scale.x <= 0.0005 && factor < 1;
+  const tooBig = this.object.scale.x >= 20 && factor > 1;
+  if (tooSmall || tooBig) return;
+
   this.setScale(this.object.scale.x * factor);
   this.dispatchEvent({ type: 'change', action: 'zoom', factor });
 };


### PR DESCRIPTION
## Description

Set limitations to how much the user can scroll in or out, plus fix issue #556.

> Note: I also updated `scss/at-import-partial-extension` to `scss/load-partial-extension` in `.stylelintrc.js` because this setting is deprecated and the linter was complaining.

## Type of changes
- Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
