### PR TITLE
Remove node 24 from Windows CI/CD config as the version is not supported by AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,6 @@ environment:
   matrix:
     - nodejs_version: "20"
     - nodejs_version: "22"
-    - nodejs_version: "24"
 cache:
   - ".yarn\\cache"
   - node_modules


### PR DESCRIPTION
## Description

#603 

- Removed Nodejs 24 from target platforms as AppVeyor doesn't support the version

see detail in https://www.appveyor.com/docs/windows-images-software/#node-js

<img width="1153" height="619" alt="image" src="https://github.com/user-attachments/assets/28296414-dc16-41d2-8c35-3ddb55297a4d" />

## Type of changes
- Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
