### PR TITLE
Add form-data patched version  to resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jpeg-js": "0.4.4",
     "semver": "7.6.3",
     "underscore": "1.13.7",
-    "express": "4.21.1"
+    "express": "4.21.1",
+    "form-data": "4.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7980,14 +7980,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.0":
-  version: 4.0.0
-  resolution: "form-data@npm:4.0.0"
+"form-data@npm:4.0.4":
+  version: 4.0.4
+  resolution: "form-data@npm:4.0.4"
   dependencies:
     asynckit: ^0.4.0
     combined-stream: ^1.0.8
+    es-set-tostringtag: ^2.1.0
+    hasown: ^2.0.2
     mime-types: ^2.1.12
-  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
+  checksum: 9b7788836df9fa5a6999e0c02515b001946b2a868cfe53f026c69e2c537a2ff9fbfb8e9d2b678744628f3dc7a2d6e14e4e45dfaf68aa6239727f0bdb8ce0abf2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fixes critical volnurability https://github.com/epam/miew/security/dependabot/196

`form-data v4.0.0` package is required by `coverall-next.js ^4.2.1`, that is required by 'jquery-terminal last version'.

`coveralls-next` has already released a fixed version `v5.0.0` referencing `form-data 4.0.4`, but we should wait for an update from `jquery-terminal` for the dep fix.

As a temporary fix I locked `form-data` patched version `v4.0.4` in resolutions.


## Type of changes

- Dependency update (non-breaking change that updates third-party packages)

## Checklist
_(Put an `x` in the boxes that apply---ideally, all five. If you're unsure about any of them, don't hesitate to ask. We're here to help!)_

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
