### PR TITLE
Add GitHub Copilot instructions file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,13 @@ Note that the core library (`miew`) is framework-agnostic and does not depend on
 
 ## Coding Standards and Conventions
 
+### Code Quality and Change Management
+- **Keep changes focused**: Each commit should address a single, well-defined issue or feature
+- **Honor Single Responsibility Principle**: Classes and functions should have one clear purpose
+- **Avoid irrelevant changes**: Don't mix formatting, refactoring, or unrelated fixes in feature commits
+- **Split large changes**: Break substantial modifications into multiple commits and pull requests for easier review
+- **One concept per PR**: Each pull request should implement one feature, fix one bug, or address one improvement
+
 ### JavaScript/ES6+
 - Follow **Airbnb JavaScript Style Guide** via ESLint configuration
 - Use ES6+ features: arrow functions, destructuring, template literals, modules


### PR DESCRIPTION
## Description

Add a `copilot-instructions.md` file to be used as a system prompt for AI agent–based development. This file should contain an overview of the project and repository, providing the agent with the essential information to get started.

> The instructions you add to your custom instruction file(s) should be short, self-contained statements that provide Copilot with relevant information to help it work in this repository. Because the instructions are sent with every chat message, they should be broadly applicable to most requests you will make in the context of the repository.

Our file is not very short, but we can evaluate whether it needs to be shortened. Let it be a subject of discussion.

See https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions?tool=vscode

## Type of changes

- New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
