### PR TITLE
Accept className, style, and common HTML props

### DIFF
--- a/packages/miew-react/jest.config.js
+++ b/packages/miew-react/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     '^.+\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }],
   },
   moduleNameMapper: {
+    '\\.module\\.[sp]?css$': 'identity-obj-proxy',
     '^.+\\.[sp]?css$': 'babel-jest',
   },
   reporters: [['jest-simple-dot-reporter', { color: true }]],

--- a/packages/miew-react/package.json
+++ b/packages/miew-react/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "^30.0.2",
     "jest-simple-dot-reporter": "^1.0.5",

--- a/packages/miew-react/src/Viewer.jsx
+++ b/packages/miew-react/src/Viewer.jsx
@@ -1,7 +1,7 @@
 import Miew from 'miew';
 import PropTypes from 'prop-types';
 import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
-import * as styles from './Viewer.module.scss';
+import styles from './Viewer.module.scss';
 import 'miew/dist/Miew.css';
 
 /**
@@ -67,10 +67,13 @@ function areOptionsEqual(prev, next) {
  * @param {Function} props.onInit - Callback function called after successful Miew initialization
  * @param {Function} props.onError - Callback function called when an error occurs during initialization
  * @param {Object} props.options - Miew configuration options
+ * @param {string} props.className - Additional CSS classes to apply to the root container
+ * @param {Object} props.style - Inline styles to apply to the root container
  * @param {*} props.theme - Legacy prop kept for backwards compatibility, will be removed in future versions
+ * @param {...Object} rest - Additional HTML attributes to spread on the root div element
  * @returns {JSX.Element} The Viewer component
  */
-export default function Viewer({ onInit, onError, options, theme }) {
+export default function Viewer({ onInit, onError, options, className, style, theme, ...rest }) {
   const miewRef = useRef();
   const rootRef = useRef();
   const onInitRef = useRef(onInit);
@@ -117,8 +120,11 @@ export default function Viewer({ onInit, onError, options, theme }) {
     return () => destroyMiewRef(miewRef);
   }, [stableOptions]);
 
+  // Merge className with existing styles.root
+  const rootClassName = className ? `${styles.root} ${className}` : styles.root;
+
   return (
-    <div className={styles.root} ref={rootRef}>
+    <div className={rootClassName} style={style} ref={rootRef} {...rest}>
       Viewer
     </div>
   );
@@ -136,6 +142,8 @@ Viewer.propTypes = {
     reps: PropTypes.arrayOf(PropTypes.object), // Representations array
     container: PropTypes.instanceOf(typeof HTMLElement !== 'undefined' ? HTMLElement : Object), // DOM container element
   }),
+  className: PropTypes.string, // Additional CSS classes
+  style: PropTypes.object, // Inline styles object
   /** @deprecated This prop is deprecated and will be removed in future versions */
   theme: PropTypes.any,
 };
@@ -144,5 +152,7 @@ Viewer.defaultProps = {
   onInit: undefined,
   onError: undefined,
   options: undefined,
+  className: undefined,
+  style: undefined,
   theme: undefined,
 };

--- a/packages/miew-react/types/Viewer.d.ts
+++ b/packages/miew-react/types/Viewer.d.ts
@@ -30,9 +30,13 @@ declare type ViewerProps = {
   onError?: (error: Error) => void;
   /** Configuration options for the Miew viewer */
   options?: ViewerOptions;
+  /** Additional CSS classes to apply to the root container */
+  className?: string;
+  /** Inline styles to apply to the root container */
+  style?: React.CSSProperties;
   /** @deprecated This prop is deprecated and will be removed in future versions */
   theme?: any;
-};
+} & React.HTMLAttributes<HTMLDivElement>;
 
 /**
  * Miew 3D Molecular Viewer React Component
@@ -61,6 +65,9 @@ declare type ViewerProps = {
  *       options={{ load: '1CRN' }}
  *       onInit={handleInit}
  *       onError={handleError}
+ *       className="custom-viewer"
+ *       style={{ border: '1px solid #ccc', borderRadius: '8px' }}
+ *       data-testid="molecular-viewer"
  *     />
  *   );
  * }
@@ -69,5 +76,13 @@ declare type ViewerProps = {
  * @param props - Component properties
  * @returns React component for 3D molecular visualization
  */
-declare const Viewer: ({ onInit, onError, options, theme }: ViewerProps) => JSX.Element;
+declare const Viewer: ({
+  onInit,
+  onError,
+  options,
+  className,
+  style,
+  theme,
+  ...rest
+}: ViewerProps) => JSX.Element;
 export default Viewer;

--- a/packages/miew-react/webpack.config.js
+++ b/packages/miew-react/webpack.config.js
@@ -44,6 +44,10 @@ const configureLib = (libName, libFile, libType) => () => ({
           {
             loader: 'css-loader',
             options: {
+              modules: {
+                auto: true,
+                namedExport: false,
+              },
               importLoaders: 1,
             },
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8585,6 +8585,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"harmony-reflect@npm:^1.4.6":
+  version: 1.6.2
+  resolution: "harmony-reflect@npm:1.6.2"
+  checksum: 2e5bae414cd2bfae5476147f9935dc69ee9b9a413206994dcb94c5b3208d4555da3d4313aff6fd14bd9991c1e3ef69cdda5c8fac1eb1d7afc064925839339b8c
+  languageName: node
+  linkType: hard
+
 "has-bigints@npm:^1.0.1, has-bigints@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-bigints@npm:1.0.2"
@@ -9058,6 +9065,15 @@ __metadata:
   peerDependencies:
     postcss: ^8.1.0
   checksum: 5c324d283552b1269cfc13a503aaaa172a280f914e5b81544f3803bc6f06a3b585fb79f66f7c771a2c052db7982c18bf92d001e3b47282e3abbbb4c4cc488d68
+  languageName: node
+  linkType: hard
+
+"identity-obj-proxy@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "identity-obj-proxy@npm:3.0.0"
+  dependencies:
+    harmony-reflect: ^1.4.6
+  checksum: 97559f8ea2aeaa1a880d279d8c49550dce01148321e00a2102cda5ddf9ce622fa1d7f3efc7bed63458af78889de888fdaebaf31c816312298bb3fdd0ef8aaf2c
   languageName: node
   linkType: hard
 
@@ -11520,6 +11536,7 @@ __metadata:
     eslint-plugin-react: ^7.37.5
     eslint-plugin-react-hooks: ^5.2.0
     eslint-plugin-react-refresh: ^0.4.20
+    identity-obj-proxy: ^3.0.0
     jest: ^30.0.2
     jest-environment-jsdom: ^30.0.2
     jest-simple-dot-reporter: ^1.0.5


### PR DESCRIPTION
## Description

Another improvement related to #612. Allow users to style the miew container and pass other common HTML div props such as `id`, `title`, event handlers, `data-` and `aria-` tags, etc.

<img width="1115" height="989" alt="shot-20250929-095936" src="https://github.com/user-attachments/assets/a1fede6d-3856-4b1e-8891-4c882e1adf04" />

Plus, fixed the way CSS modules were used in the component. Now they can be tested with Jest.

## Type of changes

- New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
