### PR TITLE
Move app tests close to the files being tested

### DIFF
--- a/packages/miew-app/src/components/menu/titlebar/Titlebar.test.js
+++ b/packages/miew-app/src/components/menu/titlebar/Titlebar.test.js
@@ -3,8 +3,8 @@ import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
 import { render, screen } from '@testing-library/react';
-import Titlebar from '../src/components/menu/titlebar/Titlebar.jsx';
-import rootReducer from '../src/reducers';
+import Titlebar from './Titlebar.jsx';
+import rootReducer from '../../../reducers';
 
 describe('<Titlebar>', () => {
   it('should render loading stage from prop', () => {


### PR DESCRIPTION
## Description

Closes #594. 
We've confirmed that the tests are configured and exist. However, one file is misplaced to a separate directory instead of being adjacent to the file being tested. This PR moves the test file.

## Type of changes

- Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
