### PR TITLE
Update miew to webgl 2

### DIFF
--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -407,15 +407,6 @@ Miew.prototype._requestAnimationFrame = function (callback) {
   requestAnimationFrame(callback);
 };
 
-function arezSpritesSupported(context) {
-  return context.getExtension('EXT_frag_depth');
-}
-
-function isAOSupported(context) {
-  return (context.getExtension('WEBGL_depth_texture')
-  && context.getExtension('WEBGL_draw_buffers'));
-}
-
 /**
  * Initialize WebGL and set 3D scene up.
  * @private
@@ -433,19 +424,11 @@ Miew.prototype._initGfx = function () {
 
   gfx.renderer2d = new CSS2DRenderer();
 
-  gfx.renderer = new THREE.WebGL1Renderer(webGLOptions);
+  gfx.renderer = new THREE.WebGLRenderer(webGLOptions);
   gfx.renderer.shadowMap.enabled = settings.now.shadow.on;
   gfx.renderer.shadowMap.autoUpdate = false;
   gfx.renderer.shadowMap.type = THREE.PCFShadowMap;
   capabilities.init(gfx.renderer);
-
-  // z-sprites and ambient occlusion possibility
-  if (!arezSpritesSupported(gfx.renderer.getContext())) {
-    settings.set('zSprites', false);
-  }
-  if (!isAOSupported(gfx.renderer.getContext())) {
-    settings.set('ao', false);
-  }
 
   gfx.renderer.autoClear = false;
   gfx.renderer.setPixelRatio(window.devicePixelRatio);
@@ -523,10 +506,8 @@ Miew.prototype._initGfx = function () {
     },
   );
 
-  if (gfx.renderer.getContext().getExtension('WEBGL_depth_texture')) {
-    gfx.offscreenBuf.depthTexture = new THREE.DepthTexture();
-    gfx.offscreenBuf.depthTexture.type = THREE.UnsignedShortType;
-  }
+  gfx.offscreenBuf.depthTexture = new THREE.DepthTexture();
+  gfx.offscreenBuf.depthTexture.type = THREE.UnsignedShortType;
 
   gfx.offscreenBuf2 = new THREE.WebGLRenderTarget(
     deviceWidth,
@@ -556,50 +537,46 @@ Miew.prototype._initGfx = function () {
   gfx.volFFTex = gfx.offscreenBuf4;
   gfx.volWFFTex = gfx.offscreenBuf;
 
-  // use float textures for volume rendering if possible
-  if (gfx.renderer.getContext().getExtension('OES_texture_float')) {
-    gfx.offscreenBuf5 = new THREE.WebGLRenderTarget(
-      deviceWidth,
-      deviceHeight,
-      {
-        minFilter: THREE.LinearFilter,
-        magFilter: THREE.LinearFilter,
-        format: THREE.RGBAFormat,
-        type: THREE.FloatType,
-        depthBuffer: false,
-      },
-    );
+  // use float textures for volume rendering (WebGL2 core feature)
+  gfx.offscreenBuf5 = new THREE.WebGLRenderTarget(
+    deviceWidth,
+    deviceHeight,
+    {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      format: THREE.RGBAFormat,
+      type: THREE.FloatType,
+      depthBuffer: false,
+    },
+  );
 
-    gfx.offscreenBuf6 = new THREE.WebGLRenderTarget(
-      deviceWidth,
-      deviceHeight,
-      {
-        minFilter: THREE.LinearFilter,
-        magFilter: THREE.LinearFilter,
-        format: THREE.RGBAFormat,
-        type: THREE.FloatType,
-        depthBuffer: false,
-      },
-    );
+  gfx.offscreenBuf6 = new THREE.WebGLRenderTarget(
+    deviceWidth,
+    deviceHeight,
+    {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      format: THREE.RGBAFormat,
+      type: THREE.FloatType,
+      depthBuffer: false,
+    },
+  );
 
-    gfx.offscreenBuf7 = new THREE.WebGLRenderTarget(
-      deviceWidth,
-      deviceHeight,
-      {
-        minFilter: THREE.LinearFilter,
-        magFilter: THREE.LinearFilter,
-        format: THREE.RGBAFormat,
-        type: THREE.FloatType,
-        depthBuffer: true,
-      },
-    );
+  gfx.offscreenBuf7 = new THREE.WebGLRenderTarget(
+    deviceWidth,
+    deviceHeight,
+    {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      format: THREE.RGBAFormat,
+      type: THREE.FloatType,
+      depthBuffer: true,
+    },
+  );
 
-    gfx.volBFTex = gfx.offscreenBuf5;
-    gfx.volFFTex = gfx.offscreenBuf6;
-    gfx.volWFFTex = gfx.offscreenBuf7;
-  } else {
-    this.logger.warn('Device doesn\'t support OES_texture_float extension');
-  }
+  gfx.volBFTex = gfx.offscreenBuf5;
+  gfx.volFFTex = gfx.offscreenBuf6;
+  gfx.volWFFTex = gfx.offscreenBuf7;
 
   gfx.stereoBufL = new THREE.WebGLRenderTarget(
     deviceWidth,
@@ -1184,11 +1161,10 @@ Miew.prototype._setUberMaterialValues = function (values) {
 Miew.prototype._enableMRT = function (on, renderBuffer, textureBuffer) {
   const gfx = this._gfx;
   const gl = gfx.renderer.getContext();
-  const ext = gl.getExtension('WEBGL_draw_buffers');
   const { properties } = gfx.renderer;
 
   if (!on) {
-    ext.drawBuffersWEBGL([gl.COLOR_ATTACHMENT0, null]);
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0, null]);
     return;
   }
 
@@ -1207,10 +1183,10 @@ Miew.prototype._enableMRT = function (on, renderBuffer, textureBuffer) {
   fb.width = renderBuffer.width;
   fb.height = renderBuffer.height;
   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tx, 0);
-  gl.framebufferTexture2D(gl.FRAMEBUFFER, ext.COLOR_ATTACHMENT1_WEBGL, gl.TEXTURE_2D, tx8, 0);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, tx8, 0);
 
-  // mapping textures
-  ext.drawBuffersWEBGL([gl.COLOR_ATTACHMENT0, ext.COLOR_ATTACHMENT1_WEBGL]);
+  // mapping textures (MRT is core feature in WebGL2)
+  gl.drawBuffers([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1]);
 };
 
 Miew.prototype._renderScene = (function () {
@@ -3692,20 +3668,11 @@ Miew.prototype._initOnSettingsChanged = function () {
   });
 
   on('ao', () => {
-    if (settings.now.ao && !isAOSupported(this._gfx.renderer.getContext())) {
-      this.logger.warn('Your device or browser does not support ao');
-      settings.set('ao', false);
-    } else {
-      const values = { normalsToGBuffer: settings.now.ao };
-      this._setUberMaterialValues(values);
-    }
+    const values = { normalsToGBuffer: settings.now.ao };
+    this._setUberMaterialValues(values);
   });
 
   on('zSprites', () => {
-    if (settings.now.zSprites && !arezSpritesSupported(this._gfx.renderer.getContext())) {
-      this.logger.warn('Your device or browser does not support zSprites');
-      settings.set('zSprites', false);
-    }
     this.rebuildAll();
   });
 

--- a/packages/miew/src/chem/Volume.js
+++ b/packages/miew/src/chem/Volume.js
@@ -291,7 +291,7 @@ class Volume {
       data,
       width,
       height,
-      THREE.LuminanceFormat,
+      THREE.RedFormat,
       THREE.UnsignedByteType,
       THREE.UVMapping,
       THREE.ClampToEdgeWrapping,

--- a/packages/miew/src/gfx/geometries/InstancedSpheresGeometry.js
+++ b/packages/miew/src/gfx/geometries/InstancedSpheresGeometry.js
@@ -25,7 +25,7 @@ class InstancedSpheresGeometry extends SphereCollisionGeo(THREE.InstancedBufferG
   constructor(spheresCount, sphereComplexity, useZSprites) {
     super(spheresCount);
     this._sphGeometry = useZSprites ? new THREE.PlaneGeometry(2, 2, 1, 1)
-      : new THREE.SphereBufferGeometry(1, sphereComplexity * 2, sphereComplexity, 0, Math.PI * 2, 0, Math.PI);
+      : new THREE.SphereGeometry(1, sphereComplexity * 2, sphereComplexity, 0, Math.PI * 2, 0, Math.PI);
     this._init(spheresCount, this._sphGeometry);
   }
 

--- a/packages/miew/src/gfx/geometries/SimpleSpheresGeometry.js
+++ b/packages/miew/src/gfx/geometries/SimpleSpheresGeometry.js
@@ -7,7 +7,7 @@ const VEC_SIZE = 3;
 
 class SimpleSpheresGeometry extends SphereCollisionGeo(ChunkedObjectsGeometry) {
   constructor(spheresCount, sphereComplexity) {
-    const sphGeometry = new THREE.SphereBufferGeometry(
+    const sphGeometry = new THREE.SphereGeometry(
       1,
       sphereComplexity * 2,
       sphereComplexity,

--- a/packages/miew/src/gfx/shaders/AO.frag
+++ b/packages/miew/src/gfx/shaders/AO.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 #define EPSILON 0.0000001
 

--- a/packages/miew/src/gfx/shaders/AOHorBlur.frag
+++ b/packages/miew/src/gfx/shaders/AOHorBlur.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 #define EPSILON 0.0000001
 

--- a/packages/miew/src/gfx/shaders/AOVertBlurWithBlend.frag
+++ b/packages/miew/src/gfx/shaders/AOVertBlurWithBlend.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 #define EPSILON 0.0000001
 

--- a/packages/miew/src/gfx/shaders/Anaglyph.frag
+++ b/packages/miew/src/gfx/shaders/Anaglyph.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 
 uniform sampler2D srcL;

--- a/packages/miew/src/gfx/shaders/FXAA.frag
+++ b/packages/miew/src/gfx/shaders/FXAA.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 
 // edge end finding algorithm parameters

--- a/packages/miew/src/gfx/shaders/Outline.frag
+++ b/packages/miew/src/gfx/shaders/Outline.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 
 uniform sampler2D srcTex;

--- a/packages/miew/src/gfx/shaders/ScreenQuad.vert
+++ b/packages/miew/src/gfx/shaders/ScreenQuad.vert
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 uniform mat4 projectionMatrix;
 uniform mat4 modelViewMatrix;
 

--- a/packages/miew/src/gfx/shaders/ScreenQuadFromDistortionTex.frag
+++ b/packages/miew/src/gfx/shaders/ScreenQuadFromDistortionTex.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 
 varying vec2 vUv;

--- a/packages/miew/src/gfx/shaders/ScreenQuadFromTex.frag
+++ b/packages/miew/src/gfx/shaders/ScreenQuadFromTex.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 
 varying vec2 vUv;

--- a/packages/miew/src/gfx/shaders/ScreenQuadFromTexWithDistortion.frag
+++ b/packages/miew/src/gfx/shaders/ScreenQuadFromTexWithDistortion.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 precision highp float;
 
 varying vec2 vUv;

--- a/packages/miew/src/gfx/shaders/Uber.frag
+++ b/packages/miew/src/gfx/shaders/Uber.frag
@@ -333,7 +333,7 @@ float unpackRGBAToDepth( const in vec4 v ) {
 
   #if defined(SHADOWMAP)
   	float texture2DCompare( sampler2D depths, vec2 uv, float compare ) {
-  		return step( compare, unpackRGBAToDepth( texture2D( depths, uv ) ) );
+  		return step( compare, unpackRGBAToDepth( texture( depths, uv ) ) );
   	}
 
     float getShadow( sampler2D shadowMap, DirectionalLightShadow dirLight, vec4 shadowCoord, vec3 vViewPosition, vec3 vNormal ) {
@@ -380,7 +380,7 @@ float unpackRGBAToDepth( const in vec4 v ) {
           vec4 vUv = ((projectionMatrix * vec4(vViewPosition, 1.0)) + 1.0) / 2.0;
           vec2 vUvNoise = vUv.xy / srcTexelSize * noiseTexelSize;
 
-          vec2 noiseVec = normalize(texture2D(noiseTex, vUvNoise).rg);
+          vec2 noiseVec = normalize(texture(noiseTex, vUvNoise).rg);
           mat2 mNoise = mat2(noiseVec.x, noiseVec.y, -noiseVec.y, noiseVec.x);
 
           vec2 offset;

--- a/packages/miew/src/gfx/shaders/Uber.frag
+++ b/packages/miew/src/gfx/shaders/Uber.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 3.00 (WebGL 2.0 compatible)
+ * No #version directive in this file (injected by Three.js).
+ * Use GLSL3 semantics (`in`/`out`, `layout(location=...)`, `texture`).
+ * Set `glslVersion: THREE.GLSL3` in ShaderMaterial/RawShaderMaterial.
+ */
+
 #if defined (NORMALS_TO_G_BUFFER)
   layout(location = 0) out vec4 fragColor;
   layout(location = 1) out vec4 fragNormal;

--- a/packages/miew/src/gfx/shaders/Uber.frag
+++ b/packages/miew/src/gfx/shaders/Uber.frag
@@ -1,11 +1,12 @@
 #if defined (NORMALS_TO_G_BUFFER)
-  #define fragColor gl_FragData[0]
+  layout(location = 0) out vec4 fragColor;
+  layout(location = 1) out vec4 fragNormal;
 #else
-  #define fragColor gl_FragColor
+  out vec4 fragColor;
 #endif
 
 #ifdef ATTR_ALPHA_COLOR
-  varying float alphaCol;
+  in float alphaCol;
 #endif
 
 #ifdef COLOR_FROM_POS
@@ -16,8 +17,8 @@
 	#if NUM_DIR_LIGHTS > 0
 		uniform sampler2D directionalShadowMap[ NUM_DIR_LIGHTS ];
     uniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHTS ]; //only for sprites
-		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
-		varying vec3 vDirectionalShadowNormal[ NUM_DIR_LIGHTS ];
+		in vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
+		in vec3 vDirectionalShadowNormal[ NUM_DIR_LIGHTS ];
     vec4 vDirLightWorldCoord[ NUM_DIR_LIGHTS ];
     vec3 vDirLightWorldNormal[ NUM_DIR_LIGHTS ];
 
@@ -35,13 +36,13 @@
 #endif
 
 #ifdef ATTR_COLOR
-  varying vec3 vColor;
+  in vec3 vColor;
 #endif
 
 #ifdef ATTR_COLOR2
-  varying vec3 vColor2;
+  in vec3 vColor2;
   #ifndef CYLINDER_SPRITE
-    varying vec2 vUv;
+    in vec2 vUv;
   #endif
 #endif
 
@@ -55,7 +56,7 @@ uniform float zClipValue;
 uniform float clipPlaneValue;
 
 #ifdef NORMALS_TO_G_BUFFER
-  varying vec3 viewNormal;
+  in vec3 viewNormal;
 #endif
 
 #define RECIPROCAL_PI 0.31830988618
@@ -68,11 +69,11 @@ uniform float clipPlaneValue;
   uniform float fogFar;
 #endif
 
-varying vec3 vWorldPosition; // world position of the pixel (invalid when INSTANCED_SPRITE is defined)
-varying vec3 vViewPosition;
+in vec3 vWorldPosition; // world position of the pixel (invalid when INSTANCED_SPRITE is defined)
+in vec3 vViewPosition;
 
 #if !defined (SPHERE_SPRITE) && !defined (CYLINDER_SPRITE)
-  varying vec3 vNormal;
+  in vec3 vNormal;
 #endif
 
 /////////////////////////////////////////// ZSprites ////////////////////////////////////////////////
@@ -81,7 +82,7 @@ varying vec3 vViewPosition;
 #endif
 
 #ifdef SPHERE_SPRITE
-  varying vec4 spritePosEye;
+  in vec4 spritePosEye;
 #endif
 
 #if defined(SPHERE_SPRITE) || defined(CYLINDER_SPRITE)
@@ -98,7 +99,7 @@ varying vec3 vViewPosition;
 #endif
 
 #ifdef SPHERE_SPRITE
-  varying vec4 instOffset;
+  in vec4 instOffset;
   uniform mat4 modelMatrix;
   uniform mat4 modelViewMatrix;
   uniform mat4 invModelViewMatrix;
@@ -173,19 +174,19 @@ varying vec3 vViewPosition;
 #endif
 
 #ifdef CYLINDER_SPRITE
-  varying vec4 matVec1;
-  varying vec4 matVec2;
-  varying vec4 matVec3;
-  varying vec4 invmatVec1;
-  varying vec4 invmatVec2;
-  varying vec4 invmatVec3;
+  in vec4 matVec1;
+  in vec4 matVec2;
+  in vec4 matVec3;
+  in vec4 invmatVec1;
+  in vec4 invmatVec2;
+  in vec4 invmatVec3;
 
   uniform mat4 modelMatrix;
   uniform mat4 modelViewMatrix;
   uniform mat4 invModelViewMatrix;
   uniform mat3 normalMatrix;
 
-  varying vec4 spritePosEye;
+  in vec4 spritePosEye;
 
   bool intersect_ray_cylinder(in vec3 origin, in vec3 ray, out vec3 point, out float frontFaced) {
 
@@ -481,7 +482,7 @@ float unpackRGBAToDepth( const in vec4 v ) {
 #ifdef DASHED_LINE
   uniform float dashedLineSize;
   uniform float dashedLinePeriod;
-  varying float vLineDistance;
+  in float vLineDistance;
 #endif
 
 /////////////////////////////////////////// Main ///////////////////////////////////////////////
@@ -623,7 +624,7 @@ void main() {
   #ifdef PREPASS_TRANSP
     fragColor = vec4(1.0, 1.0, 1.0, 1.0);
     #if defined(SPHERE_SPRITE) || defined(CYLINDER_SPRITE)
-      gl_FragDepthEXT = calcDepthForSprites(pixelPosEye, zOffset, projectionMatrix);
+      gl_FragDepth = calcDepthForSprites(pixelPosEye, zOffset, projectionMatrix);
     #endif
     return;
   #endif
@@ -659,7 +660,7 @@ void main() {
     diffuseColor.rgb *= vertexColor;
 
   #if defined(SPHERE_SPRITE) || defined(CYLINDER_SPRITE)
-    gl_FragDepthEXT = calcDepthForSprites(pixelPosEye, zOffset, projectionMatrix);
+    gl_FragDepth = calcDepthForSprites(pixelPosEye, zOffset, projectionMatrix);
   #endif
 
   #ifdef NORMALS_TO_G_BUFFER
@@ -671,7 +672,7 @@ void main() {
     #endif
     // [-1, 1] -> [0, 1]
     viewNormaInColor = 0.5 * viewNormaInColor + 0.5;
-    gl_FragData[1] = vec4(viewNormaInColor, frontFaced);
+    fragNormal = vec4(viewNormaInColor, frontFaced);
   #endif
 
   #if defined(USE_LIGHTS) && NUM_DIR_LIGHTS > 0
@@ -691,8 +692,8 @@ void main() {
   #ifdef COLOR_FROM_DEPTH
     float depth = 0.0;
     #if defined(SPHERE_SPRITE) || defined(CYLINDER_SPRITE)
-      gl_FragDepthEXT = calcDepthForSprites(pixelPosEye, zOffset, projectionMatrix);
-      depth = gl_FragDepthEXT;
+      gl_FragDepth = calcDepthForSprites(pixelPosEye, zOffset, projectionMatrix);
+      depth = gl_FragDepth;
     #else
       depth = gl_FragCoord.z;
     #endif

--- a/packages/miew/src/gfx/shaders/Uber.vert
+++ b/packages/miew/src/gfx/shaders/Uber.vert
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 3.00 (WebGL 2.0 compatible)
+ * No #version directive in this file (injected by Three.js).
+ * Use GLSL3 semantics (`in`/`out`).
+ * Set `glslVersion: THREE.GLSL3` in ShaderMaterial/RawShaderMaterial.
+ */
+
 float INSTANCED_SPRITE_OVERSCALE = 1.3;
 
 in vec3 normal;

--- a/packages/miew/src/gfx/shaders/Uber.vert
+++ b/packages/miew/src/gfx/shaders/Uber.vert
@@ -1,74 +1,74 @@
 float INSTANCED_SPRITE_OVERSCALE = 1.3;
 
-attribute vec3 normal;
+in vec3 normal;
 
 #ifdef NORMALS_TO_G_BUFFER
-  varying vec3 viewNormal;
+  out vec3 viewNormal;
 #endif
 #if !defined (SPHERE_SPRITE) && !defined (CYLINDER_SPRITE)
-  varying vec3 vNormal;
+  out vec3 vNormal;
 #endif
 
 #ifdef THICK_LINE
-  attribute vec4 position; // W contains vert pos or neg offset
+  in vec4 position; // W contains vert pos or neg offset
 #else
-  attribute vec3 position;
+  in vec3 position;
 #endif
 
-varying vec3 vWorldPosition;
-varying vec3 vViewPosition;
+out vec3 vWorldPosition;
+out vec3 vViewPosition;
 
 #ifdef ATTR_ALPHA_COLOR
-  attribute float alphaColor;
-  varying float alphaCol;
+  in float alphaColor;
+  out float alphaCol;
 #endif
 
 #if defined(USE_LIGHTS) && defined(SHADOWMAP)
 	#if NUM_DIR_LIGHTS > 0
 		uniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHTS ];
-		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
-		varying vec3 vDirectionalShadowNormal[ NUM_DIR_LIGHTS ];
+		out vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
+		out vec3 vDirectionalShadowNormal[ NUM_DIR_LIGHTS ];
 	#endif
 #endif
 
 #ifdef ATTR_COLOR
-  attribute vec3 color;
-  varying vec3 vColor;
+  in vec3 color;
+  out vec3 vColor;
 #endif
 
 #ifdef ATTR_COLOR2
-  attribute vec3 color2;
-  varying vec3 vColor2;
-  attribute vec2 uv;
+  in vec3 color2;
+  out vec3 vColor2;
+  in vec2 uv;
   #ifndef CYLINDER_SPRITE
-    varying vec2 vUv;
+    out vec2 vUv;
   #endif
 #endif
 
 #ifdef INSTANCED_POS
-  attribute vec4 offset;
+  in vec4 offset;
   #ifdef SPHERE_SPRITE
-    varying vec4 instOffset;
-  varying vec4 spritePosEye;
+    out vec4 instOffset;
+    out vec4 spritePosEye;
   #endif
 #endif
 
 #ifdef INSTANCED_MATRIX
-  attribute vec4 matVector1;
-  attribute vec4 matVector2;
-  attribute vec4 matVector3;
-  attribute vec4 invmatVector1;
-  attribute vec4 invmatVector2;
-  attribute vec4 invmatVector3;
+  in vec4 matVector1;
+  in vec4 matVector2;
+  in vec4 matVector3;
+  in vec4 invmatVector1;
+  in vec4 invmatVector2;
+  in vec4 invmatVector3;
 
   #ifdef CYLINDER_SPRITE
-    varying vec4 matVec1;
-    varying vec4 matVec2;
-    varying vec4 matVec3;
-    varying vec4 invmatVec1;
-    varying vec4 invmatVec2;
-    varying vec4 invmatVec3;
-    varying vec4 spritePosEye;
+    out vec4 matVec1;
+    out vec4 matVec2;
+    out vec4 matVec3;
+    out vec4 invmatVec1;
+    out vec4 invmatVec2;
+    out vec4 invmatVec3;
+    out vec4 spritePosEye;
   #endif
 #endif
 
@@ -78,12 +78,12 @@ uniform mat3 normalMatrix; // optional
 uniform mat4 modelMatrix; // optional
 
 #ifdef DASHED_LINE
-  attribute float lineDistance;
-  varying float vLineDistance;
+  in float lineDistance;
+  out float vLineDistance;
 #endif
 
 #ifdef THICK_LINE
-  attribute vec3 direction;
+  in vec3 direction;
   uniform mat4 projMatrixInv;
   uniform vec2 viewport;
   uniform float lineWidth;

--- a/packages/miew/src/gfx/shaders/UberMaterial.js
+++ b/packages/miew/src/gfx/shaders/UberMaterial.js
@@ -174,9 +174,10 @@ class UberMaterial extends THREE.RawShaderMaterial {
 
     // set default values
     super.setValues({
-      uniforms: THREE.UniformsUtils.clone(defaultUniforms),
+      glslVersion: THREE.GLSL3,
       vertexShader: this.precisionString() + vertexShader,
       fragmentShader: this.precisionString() + fragmentShader,
+      uniforms: THREE.UniformsUtils.clone(defaultUniforms),
       lights: true,
       fog: true,
       side: THREE.DoubleSide,

--- a/packages/miew/src/gfx/shaders/Volume.frag
+++ b/packages/miew/src/gfx/shaders/Volume.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 uniform mat4 projectionMatrix;
 
 // 3D volume texture

--- a/packages/miew/src/gfx/shaders/Volume.vert
+++ b/packages/miew/src/gfx/shaders/Volume.vert
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 varying vec4 screenSpacePos;
 
 void main() {

--- a/packages/miew/src/gfx/shaders/VolumeFaces.frag
+++ b/packages/miew/src/gfx/shaders/VolumeFaces.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 varying vec3 pos;
 
 void main() {

--- a/packages/miew/src/gfx/shaders/VolumeFaces.vert
+++ b/packages/miew/src/gfx/shaders/VolumeFaces.vert
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 varying vec3 pos;
 
 void main() {

--- a/packages/miew/src/gfx/shaders/VolumeFarPlane.frag
+++ b/packages/miew/src/gfx/shaders/VolumeFarPlane.frag
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 varying vec4 volPos;
 
 void main() {

--- a/packages/miew/src/gfx/shaders/VolumeFarPlane.vert
+++ b/packages/miew/src/gfx/shaders/VolumeFarPlane.vert
@@ -1,3 +1,10 @@
+/*
+ * GLSL Version: ES 1.00 (WebGL 1.0 compatible)
+ * No #version directive in this file.
+ * Use GLSL1 semantics (`attribute`/`varying`, `texture2D`, `gl_FragColor`).
+ * Keep `glslVersion` as default (GLSL1) or set `THREE.GLSL1` explicitly.
+ */
+
 varying vec4 volPos;
 uniform float aspectRatio;
 uniform float farZ;


### PR DESCRIPTION
## Description
Solves #631 
Minimal updates were done to move from WebGL1 to WebGL2
- Additionally some shaders were moved to GLSL 3 (comments were added to all shaders to easily get used in them glsl versions)

## Type of changes
None from suggested. WebGL update with no breaking changes and changes in behavior at all (hopefully)

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] The changes do not require updated tests.
- [x] The changes do not require updated docs.
- [x] Checked that actual stereo modes are not broken ('SIMPLE', 'DISTORTED', 'ANAGLYPH')
