### PR TITLE
Fix always-false empty array check in _enterComponentEditMode

### DIFF
--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -2645,7 +2645,7 @@ Miew.prototype._enterComponentEditMode = function () {
     }
   });
 
-  if (editors === []) {
+  if (editors.length === 0) {
     return;
   }
 


### PR DESCRIPTION
## Description

Fixes #639.

In JavaScript, comparing two objects with `===` checks reference identity, not content. A freshly created `[]` is never the same reference as the `editors` array, so this condition always evaluated to `false` and the early return never fired.

## Type of changes

- Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read CONTRIBUTING and CODE_OF_CONDUCT guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
