### PR TITLE
Fix selection cleanup on visual unload

### DIFF
--- a/packages/miew/package.json
+++ b/packages/miew/package.json
@@ -127,6 +127,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^18.0.0",
     "open": "^11.0.0",
+    "pirates": "^4.0.7",
     "postcss": "^8.5.15",
     "postcss-advanced-variables": "^5.0.0",
     "postcss-calc": "^10.1.1",

--- a/packages/miew/src/ComplexVisual.js
+++ b/packages/miew/src/ComplexVisual.js
@@ -49,7 +49,7 @@ class ComplexVisual extends Visual {
 
   release() {
     if (this._selectionGeometry.parent) {
-      this._selectionGeometry.remove(this._selectionGeometry);
+      this._selectionGeometry.parent.remove(this._selectionGeometry);
     }
     Visual.prototype.release.call(this);
   }

--- a/packages/miew/src/ComplexVisual.test.js
+++ b/packages/miew/src/ComplexVisual.test.js
@@ -1,0 +1,23 @@
+import chai, { expect } from 'chai';
+import dirtyChai from 'dirty-chai';
+import * as THREE from 'three';
+import ComplexVisual from './ComplexVisual';
+import Complex from './chem/Complex';
+
+chai.use(dirtyChai);
+
+describe('ComplexVisual', () => {
+  describe('release', () => {
+    it('removes selection geometry from its parent', () => {
+      const complex = new Complex();
+      const visual = new ComplexVisual('test', complex);
+      const parent = new THREE.Group();
+
+      parent.add(visual.getSelectionGeo());
+      expect(visual.getSelectionGeo().parent).to.equal(parent);
+
+      visual.release();
+      expect(visual.getSelectionGeo().parent).to.be.null();
+    });
+  });
+});

--- a/packages/miew/tools/babel-register-wrapper.js
+++ b/packages/miew/tools/babel-register-wrapper.js
@@ -1,11 +1,7 @@
-const fs = require('fs');
 const { addHook } = require('pirates');
 
 addHook(
-  (code, filename) => {
-    const content = fs.readFileSync(filename, 'utf8');
-    return `module.exports = ${JSON.stringify(content)};`;
-  },
+  (code) => `module.exports = ${JSON.stringify(code)};`,
   { exts: ['.vert', '.frag'] },
 );
 

--- a/packages/miew/tools/babel-register-wrapper.js
+++ b/packages/miew/tools/babel-register-wrapper.js
@@ -1,3 +1,14 @@
+const fs = require('fs');
+const { addHook } = require('pirates');
+
+addHook(
+  (code, filename) => {
+    const content = fs.readFileSync(filename, 'utf8');
+    return `module.exports = ${JSON.stringify(content)};`;
+  },
+  { exts: ['.vert', '.frag'] },
+);
+
 require('@babel/register')({
   rootMode: 'upward',
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10095,6 +10095,7 @@ __metadata:
     npm-run-all: ^4.1.5
     nyc: ^18.0.0
     open: ^11.0.0
+    pirates: ^4.0.7
     postcss: ^8.5.15
     postcss-advanced-variables: ^5.0.0
     postcss-calc: ^10.1.1


### PR DESCRIPTION
## Description

Fixes #601.

Selection geometry was not cleared when unloading a visual because `release()` was attempting to remove the selection geometry from itself rather than from its parent pivot group.

Changes:
- Corrected `release()` in `ComplexVisual` to remove the selection geometry from its parent.
- Added `pirates` to devDependencies and registered `.vert`/`.frag` hooks in the test registration wrapper to allow unit testing of components that import shaders.
- Added a unit test verifying that selection geometry is detached upon release.

## Type of changes

- Dependency update (non-breaking change that updates third-party packages)
- Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works.
- [x] The changes do not require updated docs.
