### PR TITLE
Add a setting to switch auto-bonding off

### DIFF
--- a/packages/miew/CHANGELOG.md
+++ b/packages/miew/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a description to the "Project an atom onto the canvas" example, explaining why the
   HTML marker stays visible while the canvas-drawn marker disappears when the tracked atom
   moves outside the viewer's bounds.
-- Add an `autoBonding` setting (`'default'|'disable'|'force'`) to control whether bonds are
-  automatically reconstructed on load, independent of file format. Can be overridden per `load()`
-  call via `opts.autoBonding`.
+- Add an `autoBonding` setting (`'default'|'disable'|'force'|'nohetatm'`) to control whether bonds
+  are automatically reconstructed on load, independent of file format. `'nohetatm'` excludes HETATM
+  atoms from auto-bonding (in either direction) while still reconstructing bonds for the rest of
+  the structure per the format's default behavior; it only has an effect for formats with a
+  genuine per-atom HETATM distinction (PDB, CIF, MMTF). Can be overridden per `load()` call via
+  `opts.autoBonding`.
 
 ### Fixed
 

--- a/packages/miew/CHANGELOG.md
+++ b/packages/miew/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a description to the "Project an atom onto the canvas" example, explaining why the
   HTML marker stays visible while the canvas-drawn marker disappears when the tracked atom
   moves outside the viewer's bounds.
+- Add an `autoBonding` setting (`'default'|'disable'|'force'`) to control whether bonds are
+  automatically reconstructed on load, independent of file format. Can be overridden per `load()`
+  call via `opts.autoBonding`.
 
 ### Fixed
 

--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -1960,6 +1960,8 @@ function _parseData(data, opts, job) {
  * @param {string=} opts.fileType - Data contents type (e.g. 'pdb', 'cml').
  * @param {string=} opts.mdFile - .nc file path.
  * @param {boolean=} opts.keepRepsInfo - prevent reset of object and reps information.
+ * @param {string=} opts.autoBonding - Override the `autoBonding` setting for this load only
+ *   ('default'|'disable'|'force').
  * @returns {Promise} name of the visual that was added to the viewer
  */
 Miew.prototype.load = function (source, opts) {

--- a/packages/miew/src/Miew.js
+++ b/packages/miew/src/Miew.js
@@ -1961,7 +1961,8 @@ function _parseData(data, opts, job) {
  * @param {string=} opts.mdFile - .nc file path.
  * @param {boolean=} opts.keepRepsInfo - prevent reset of object and reps information.
  * @param {string=} opts.autoBonding - Override the `autoBonding` setting for this load only
- *   ('default'|'disable'|'force').
+ *   ('default'|'disable'|'force'|'nohetatm'). 'nohetatm' only has an effect for formats with a
+ *   genuine per-atom HETATM distinction (PDB, CIF, MMTF).
  * @returns {Promise} name of the visual that was added to the viewer
  */
 Miew.prototype.load = function (source, opts) {

--- a/packages/miew/src/chem/AutoBond.js
+++ b/packages/miew/src/chem/AutoBond.js
@@ -23,28 +23,35 @@ function _getBondingRadius(atom) {
   throw new Error('_getBondingRadius: Logic error.');
 }
 
-function _isAtomEligible(atom) {
-  // build for all non-hetatm and for hetatm without bonds
-  return !atom.isHet() || (atom.bonds && atom.bonds.length === 0);
-}
-
 /**
  * Bond between atoms.
  *
  * @param {Complex} complex molecular complex
+ * @param {object} [opts] - Options.
+ * @param {boolean} [opts.excludeHetatm] - Exclude HETATM atoms from auto-bonding entirely,
+ *   instead of only skipping hetatm atoms that already have bonds.
 
  * @exports AutoBond
  * @constructor
  */
 class AutoBond {
-  constructor(complex) {
+  constructor(complex, opts) {
     this._complex = complex;
     this._maxRad = 1.8;
     const bBox = this._complex.getDefaultBoundaries().boundingBox;
     this._vBoxMin = bBox.min.clone();
     this._vBoxMax = bBox.max.clone();
 
+    this._excludeHetatm = !!(opts && opts.excludeHetatm);
     this._pairCollection = null;
+  }
+
+  _isAtomEligible(atom) {
+    if (this._excludeHetatm) {
+      return !atom.isHet();
+    }
+    // build for all non-hetatm and for hetatm without bonds
+    return !atom.isHet() || (atom.bonds && atom.bonds.length === 0);
   }
 
   /**
@@ -88,6 +95,10 @@ class AutoBond {
     let atomA;
 
     const processAtom = function (atomB) {
+      if (self._excludeHetatm && atomB.isHet()) {
+        return;
+      }
+
       if (isHydrogenA && atomB.isHydrogen()) {
         return;
       }
@@ -116,7 +127,7 @@ class AutoBond {
 
     for (let i = 0; i < atomsNum; ++i) {
       atomA = atoms[i];
-      if (!_isAtomEligible(atomA)) {
+      if (!this._isAtomEligible(atomA)) {
         continue;
       }
 

--- a/packages/miew/src/chem/AutoBond.test.js
+++ b/packages/miew/src/chem/AutoBond.test.js
@@ -1,0 +1,114 @@
+import chai, { expect } from 'chai';
+import dirtyChai from 'dirty-chai';
+import * as THREE from 'three';
+import Complex from './Complex';
+import Element from './Element';
+
+chai.use(dirtyChai);
+
+// Carbon's bonding radius is 0.68, and the default bonding tolerance is 0.45, so two carbon
+// atoms placed 1.5 angstrom apart are well within the ~1.81 angstrom bonding cutoff. The offset
+// is spread across all three axes (rather than along a single one) so the complex's bounding box
+// isn't degenerate on any axis, which the voxel-based neighbor search relies on.
+const cBondedOffset = { x: 1, y: 1, z: 0.5 }; // magnitude === 1.5
+
+function buildComplex(atomSpecs) {
+  const complex = new Complex();
+  const chain = complex.addChain('A');
+  const residue = chain.addResidue('ALA', 1, ' ');
+  const element = Element.getByName('C');
+
+  const atoms = atomSpecs.map((spec, i) => residue.addAtom(
+    `A${i}`,
+    element,
+    new THREE.Vector3(spec.x, spec.y, spec.z),
+    undefined,
+    spec.het,
+  ));
+
+  return { complex, atoms };
+}
+
+describe('AutoBond (via Complex#finalize)', () => {
+  it('bonds two regular atoms within bonding distance', () => {
+    const { complex, atoms } = buildComplex([
+      { x: 0, y: 0, z: 0 },
+      { ...cBondedOffset },
+    ]);
+
+    complex.finalize({ needAutoBonding: true, detectAromaticLoops: false, enableEditing: false });
+
+    expect(atoms[0].bonds).to.have.lengthOf(1);
+    expect(atoms[1].bonds).to.have.lengthOf(1);
+  });
+
+  it('bonds a hetatm atom without existing bonds by default', () => {
+    const { complex, atoms } = buildComplex([
+      {
+        x: 0, y: 0, z: 0, het: true,
+      },
+      { ...cBondedOffset },
+    ]);
+
+    complex.finalize({ needAutoBonding: true, detectAromaticLoops: false, enableEditing: false });
+
+    expect(atoms[0].bonds).to.have.lengthOf(1);
+    expect(atoms[1].bonds).to.have.lengthOf(1);
+  });
+
+  it('excludes a hetatm atom from auto-bonding when excludeHetatmFromAutoBonding is set', () => {
+    const { complex, atoms } = buildComplex([
+      {
+        x: 0, y: 0, z: 0, het: true,
+      },
+      { ...cBondedOffset },
+    ]);
+
+    complex.finalize({
+      needAutoBonding: true,
+      excludeHetatmFromAutoBonding: true,
+      detectAromaticLoops: false,
+      enableEditing: false,
+    });
+
+    expect(atoms[0].bonds).to.have.lengthOf(0);
+    expect(atoms[1].bonds).to.have.lengthOf(0);
+  });
+
+  it('still bonds two regular (non-hetatm) atoms when excludeHetatmFromAutoBonding is set', () => {
+    const { complex, atoms } = buildComplex([
+      { x: 0, y: 0, z: 0 },
+      { ...cBondedOffset },
+    ]);
+
+    complex.finalize({
+      needAutoBonding: true,
+      excludeHetatmFromAutoBonding: true,
+      detectAromaticLoops: false,
+      enableEditing: false,
+    });
+
+    expect(atoms[0].bonds).to.have.lengthOf(1);
+    expect(atoms[1].bonds).to.have.lengthOf(1);
+  });
+
+  it('keeps a hetatm atom eligible for its pre-existing bonds even when excluded', () => {
+    const { complex, atoms } = buildComplex([
+      {
+        x: 0, y: 0, z: 0, het: true,
+      },
+      { ...cBondedOffset, het: true },
+    ]);
+    complex.addBond(atoms[0], atoms[1]);
+
+    complex.finalize({
+      needAutoBonding: true,
+      excludeHetatmFromAutoBonding: true,
+      detectAromaticLoops: false,
+      enableEditing: false,
+    });
+
+    expect(atoms[0].bonds).to.have.lengthOf(1);
+    expect(atoms[1].bonds).to.have.lengthOf(1);
+  });
+});

--- a/packages/miew/src/chem/Complex.js
+++ b/packages/miew/src/chem/Complex.js
@@ -459,6 +459,7 @@ class Complex {
    * Finalizes complex's inner data(i.e. after parsing).
    * @param {objects} opts - Build bonds automatically.
    * @param {boolean} opts.needAutoBonding     - Build bonds automatically.
+   * @param {boolean} [opts.excludeHetatmFromAutoBonding] - Exclude HETATM atoms from auto-bonding.
    * @param {boolean} opts.detectAromaticLoops - Find/mark aromatic loops.
    * @param {boolean} opts.enableEditing       - Restructure Complex to enable per-component editing.
    * @param {Array<Atom>} [opts.serialAtomMap] - Array of atoms ordered by their serials.
@@ -535,7 +536,7 @@ class Complex {
     if (opts.needAutoBonding) {
       // Ignore errors during autobonding
       try {
-        const autoConnector = new AutoBond(this);
+        const autoConnector = new AutoBond(this, { excludeHetatm: opts.excludeHetatmFromAutoBonding });
         autoConnector.build();
         autoConnector.destroy();
       } catch (e) {

--- a/packages/miew/src/io/parsers/CIFParser.js
+++ b/packages/miew/src/io/parsers/CIFParser.js
@@ -179,6 +179,7 @@ class CIFParser extends Parser {
     this._extractMetadata(complex, complexData);
     complex.finalize({
       needAutoBonding: this.resolveAutoBonding(true),
+      excludeHetatmFromAutoBonding: this.excludeHetatmFromAutoBonding(),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
     });

--- a/packages/miew/src/io/parsers/CIFParser.js
+++ b/packages/miew/src/io/parsers/CIFParser.js
@@ -178,7 +178,7 @@ class CIFParser extends Parser {
     this._extractMolecules(complex, complexData);
     this._extractMetadata(complex, complexData);
     complex.finalize({
-      needAutoBonding: true,
+      needAutoBonding: this.resolveAutoBonding(true),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
     });

--- a/packages/miew/src/io/parsers/CMLParser.js
+++ b/packages/miew/src/io/parsers/CMLParser.js
@@ -611,7 +611,7 @@ class CMLParser extends Parser {
     this._complex.originalCML = data.originalCML;
     this._fixBondsArray();
     complex.finalize({
-      needAutoBonding: false,
+      needAutoBonding: this.resolveAutoBonding(false),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/io/parsers/GROParser.js
+++ b/packages/miew/src/io/parsers/GROParser.js
@@ -146,7 +146,7 @@ class GROParser extends Parser {
     this._complex._molecules[0] = molecule;
     this._molecules.push(molecule);
     this._complex.finalize({
-      needAutoBonding: true,
+      needAutoBonding: this.resolveAutoBonding(true),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/io/parsers/MMTFParser.js
+++ b/packages/miew/src/io/parsers/MMTFParser.js
@@ -463,7 +463,7 @@ class MMTFParser extends Parser {
     this._joinSynonymousChains();
 
     this._complex.finalize({
-      needAutoBonding: false,
+      needAutoBonding: this.resolveAutoBonding(false),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/io/parsers/MMTFParser.js
+++ b/packages/miew/src/io/parsers/MMTFParser.js
@@ -464,6 +464,7 @@ class MMTFParser extends Parser {
 
     this._complex.finalize({
       needAutoBonding: this.resolveAutoBonding(false),
+      excludeHetatmFromAutoBonding: this.excludeHetatmFromAutoBonding(),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/io/parsers/MOL2Parser.js
+++ b/packages/miew/src/io/parsers/MOL2Parser.js
@@ -276,7 +276,7 @@ class MOL2Parser extends Parser {
     this._finalizeMolecules();
 
     this._complex.finalize({
-      needAutoBonding: false,
+      needAutoBonding: this.resolveAutoBonding(false),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/io/parsers/PDBParser.js
+++ b/packages/miew/src/io/parsers/PDBParser.js
@@ -89,7 +89,7 @@ class PDBParser extends Parser {
 
     // create secondary structure etc.
     this._complex.finalize({
-      needAutoBonding: true,
+      needAutoBonding: this.resolveAutoBonding(true),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/io/parsers/PDBParser.js
+++ b/packages/miew/src/io/parsers/PDBParser.js
@@ -90,6 +90,7 @@ class PDBParser extends Parser {
     // create secondary structure etc.
     this._complex.finalize({
       needAutoBonding: this.resolveAutoBonding(true),
+      excludeHetatmFromAutoBonding: this.excludeHetatmFromAutoBonding(),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/io/parsers/Parser.js
+++ b/packages/miew/src/io/parsers/Parser.js
@@ -33,6 +33,26 @@ export default class Parser {
     return this.model;
   }
 
+  /**
+   * Resolve whether auto-bonding should be performed for this parse, taking into account
+   * (in order of precedence) a per-load override (`opts.autoBonding` passed to {@link Miew#load}),
+   * the global `autoBonding` setting, and finally the format's own default behavior.
+   * @param {boolean} formatDefault - Whether this format reconstructs bonds by default.
+   * @returns {boolean} true if bonds should be automatically reconstructed.
+   */
+  resolveAutoBonding(formatDefault) {
+    const mode = this._options.autoBonding !== undefined
+      ? this._options.autoBonding
+      : this.settings.now.autoBonding;
+    if (mode === 'force') {
+      return true;
+    }
+    if (mode === 'disable') {
+      return false;
+    }
+    return formatDefault;
+  }
+
   abort() {
     this._abort = true;
   }

--- a/packages/miew/src/io/parsers/Parser.js
+++ b/packages/miew/src/io/parsers/Parser.js
@@ -34,6 +34,18 @@ export default class Parser {
   }
 
   /**
+   * Resolve the effective `autoBonding` mode for this parse, taking into account
+   * (in order of precedence) a per-load override (`opts.autoBonding` passed to {@link Miew#load})
+   * and the global `autoBonding` setting.
+   * @returns {string} the effective mode ('default'|'disable'|'force'|'nohetatm').
+   */
+  _resolveAutoBondingMode() {
+    return this._options.autoBonding !== undefined
+      ? this._options.autoBonding
+      : this.settings.now.autoBonding;
+  }
+
+  /**
    * Resolve whether auto-bonding should be performed for this parse, taking into account
    * (in order of precedence) a per-load override (`opts.autoBonding` passed to {@link Miew#load}),
    * the global `autoBonding` setting, and finally the format's own default behavior.
@@ -41,9 +53,7 @@ export default class Parser {
    * @returns {boolean} true if bonds should be automatically reconstructed.
    */
   resolveAutoBonding(formatDefault) {
-    const mode = this._options.autoBonding !== undefined
-      ? this._options.autoBonding
-      : this.settings.now.autoBonding;
+    const mode = this._resolveAutoBondingMode();
     if (mode === 'force') {
       return true;
     }
@@ -51,6 +61,16 @@ export default class Parser {
       return false;
     }
     return formatDefault;
+  }
+
+  /**
+   * Resolve whether HETATM atoms should be excluded from auto-bonding, taking into account
+   * (in order of precedence) a per-load override (`opts.autoBonding` passed to {@link Miew#load})
+   * and the global `autoBonding` setting.
+   * @returns {boolean} true if HETATM atoms should be excluded from auto-bonding.
+   */
+  excludeHetatmFromAutoBonding() {
+    return this._resolveAutoBondingMode() === 'nohetatm';
   }
 
   abort() {

--- a/packages/miew/src/io/parsers/Parser.test.js
+++ b/packages/miew/src/io/parsers/Parser.test.js
@@ -109,12 +109,68 @@ describe('Parser', () => {
       expect(parser.resolveAutoBonding(true)).to.be.false();
     });
 
-    it('falls back to the format default for an unrecognized mode', () => {
+    it('falls back to the format default when the setting is "nohetatm"', () => {
       const parser = new Parser();
       withSetting(parser, 'nohetatm');
 
       expect(parser.resolveAutoBonding(true)).to.be.true();
       expect(parser.resolveAutoBonding(false)).to.be.false();
+    });
+
+    it('falls back to the format default for an unrecognized mode', () => {
+      const parser = new Parser();
+      withSetting(parser, 'bogus-mode');
+
+      expect(parser.resolveAutoBonding(true)).to.be.true();
+      expect(parser.resolveAutoBonding(false)).to.be.false();
+    });
+  });
+
+  describe('#excludeHetatmFromAutoBonding()', () => {
+    function withSetting(parser, value) {
+      parser.context = { settings: { now: { autoBonding: value } } };
+    }
+
+    it('returns false when the setting is "default"', () => {
+      const parser = new Parser();
+      withSetting(parser, 'default');
+
+      expect(parser.excludeHetatmFromAutoBonding()).to.be.false();
+    });
+
+    it('returns false when the setting is "disable"', () => {
+      const parser = new Parser();
+      withSetting(parser, 'disable');
+
+      expect(parser.excludeHetatmFromAutoBonding()).to.be.false();
+    });
+
+    it('returns false when the setting is "force"', () => {
+      const parser = new Parser();
+      withSetting(parser, 'force');
+
+      expect(parser.excludeHetatmFromAutoBonding()).to.be.false();
+    });
+
+    it('returns true when the setting is "nohetatm"', () => {
+      const parser = new Parser();
+      withSetting(parser, 'nohetatm');
+
+      expect(parser.excludeHetatmFromAutoBonding()).to.be.true();
+    });
+
+    it('lets a per-load override win over the setting ("nohetatm" overrides "force")', () => {
+      const parser = new Parser(null, { autoBonding: 'nohetatm' });
+      withSetting(parser, 'force');
+
+      expect(parser.excludeHetatmFromAutoBonding()).to.be.true();
+    });
+
+    it('lets a per-load override win over the setting ("force" overrides "nohetatm")', () => {
+      const parser = new Parser(null, { autoBonding: 'force' });
+      withSetting(parser, 'nohetatm');
+
+      expect(parser.excludeHetatmFromAutoBonding()).to.be.false();
     });
   });
 });

--- a/packages/miew/src/io/parsers/Parser.test.js
+++ b/packages/miew/src/io/parsers/Parser.test.js
@@ -67,4 +67,54 @@ describe('Parser', () => {
       });
     });
   });
+
+  describe('#resolveAutoBonding()', () => {
+    function withSetting(parser, value) {
+      parser.context = { settings: { now: { autoBonding: value } } };
+    }
+
+    it('falls back to the format default when the setting is "default"', () => {
+      const parser = new Parser();
+      withSetting(parser, 'default');
+
+      expect(parser.resolveAutoBonding(true)).to.be.true();
+      expect(parser.resolveAutoBonding(false)).to.be.false();
+    });
+
+    it('returns true when the setting is "force", regardless of format default', () => {
+      const parser = new Parser();
+      withSetting(parser, 'force');
+
+      expect(parser.resolveAutoBonding(false)).to.be.true();
+    });
+
+    it('returns false when the setting is "disable", regardless of format default', () => {
+      const parser = new Parser();
+      withSetting(parser, 'disable');
+
+      expect(parser.resolveAutoBonding(true)).to.be.false();
+    });
+
+    it('lets a per-load override win over the setting ("force" overrides "disable")', () => {
+      const parser = new Parser(null, { autoBonding: 'force' });
+      withSetting(parser, 'disable');
+
+      expect(parser.resolveAutoBonding(false)).to.be.true();
+    });
+
+    it('lets a per-load override win over the setting ("disable" overrides "force")', () => {
+      const parser = new Parser(null, { autoBonding: 'disable' });
+      withSetting(parser, 'force');
+
+      expect(parser.resolveAutoBonding(true)).to.be.false();
+    });
+
+    it('falls back to the format default for an unrecognized mode', () => {
+      const parser = new Parser();
+      withSetting(parser, 'nohetatm');
+
+      expect(parser.resolveAutoBonding(true)).to.be.true();
+      expect(parser.resolveAutoBonding(false)).to.be.false();
+    });
+  });
 });

--- a/packages/miew/src/io/parsers/PubChemParser.js
+++ b/packages/miew/src/io/parsers/PubChemParser.js
@@ -26,7 +26,7 @@ class PubChemParser extends Parser {
     if (complexData) {
       this._extractAtoms(complex, complexData);
       complex.finalize({
-        needAutoBonding: false,
+        needAutoBonding: this.resolveAutoBonding(false),
         detectAromaticLoops: this.settings.now.aromatic,
         enableEditing: this.settings.now.editing,
       });

--- a/packages/miew/src/io/parsers/SDFParser.js
+++ b/packages/miew/src/io/parsers/SDFParser.js
@@ -310,7 +310,10 @@ export default class SDFParser extends Parser {
     this._complex.units = this._complex.units.concat(this._assemblies);
     this._buildMolecules();
     this._complex.finalize({
-      needAutoBonding: false, detectAromaticLoops: false, enableEditing: false, serialAtomMap: this._serialAtomMap,
+      needAutoBonding: this.resolveAutoBonding(false),
+      detectAromaticLoops: false,
+      enableEditing: false,
+      serialAtomMap: this._serialAtomMap,
     });
   }
 

--- a/packages/miew/src/io/parsers/XYZParser.js
+++ b/packages/miew/src/io/parsers/XYZParser.js
@@ -83,7 +83,7 @@ class XYZParser extends Parser {
     this._parseAtomsInf();
 
     this._complex.finalize({
-      needAutoBonding: true,
+      needAutoBonding: this.resolveAutoBonding(true),
       detectAromaticLoops: this.settings.now.aromatic,
       enableEditing: this.settings.now.editing,
       serialAtomMap: this._serialAtomMap,

--- a/packages/miew/src/settings.js
+++ b/packages/miew/src/settings.js
@@ -864,6 +864,20 @@ const defaults = {
   aromatic: false,
 
   /**
+   * Control auto-bonding behavior when building a complex.
+   *
+   * - "default": keep the per-format behavior (some formats reconstruct bonds, some don't),
+   * - "disable": never reconstruct bonds, regardless of format,
+   * - "force":   always reconstruct bonds, regardless of format.
+   *
+   * Can be overridden per {@link Miew#load} call via `opts.autoBonding`.
+   *
+   * @type {string}
+   * @instance
+   */
+  autoBonding: 'default',
+
+  /**
    * Load only one biological unit from all those described in PDB file.
    * @type {boolean}
    * @instance

--- a/packages/miew/src/settings.js
+++ b/packages/miew/src/settings.js
@@ -866,9 +866,13 @@ const defaults = {
   /**
    * Control auto-bonding behavior when building a complex.
    *
-   * - "default": keep the per-format behavior (some formats reconstruct bonds, some don't),
-   * - "disable": never reconstruct bonds, regardless of format,
-   * - "force":   always reconstruct bonds, regardless of format.
+   * - "default":  keep the per-format behavior (some formats reconstruct bonds, some don't),
+   * - "disable":  never reconstruct bonds, regardless of format,
+   * - "force":    always reconstruct bonds, regardless of format,
+   * - "nohetatm": reconstruct bonds per the format's default behavior, but exclude HETATM
+   *               atoms from auto-bonding. Only has an effect for formats with a genuine
+   *               per-atom HETATM distinction (PDB, CIF, MMTF); other formats behave as
+   *               with "default".
    *
    * Can be overridden per {@link Miew#load} call via `opts.autoBonding`.
    *

--- a/packages/miew/src/settings.test.js
+++ b/packages/miew/src/settings.test.js
@@ -62,6 +62,14 @@ describe('settings', () => {
     });
   });
 
+  describe('defaults', () => {
+    it('defaults autoBonding to "default"', () => {
+      const s = new Settings();
+
+      expect(s.now.autoBonding).to.equal('default');
+    });
+  });
+
   describe('.reset()', () => {
     it('resets all parameters to default values', () => {
       const s = new Settings();


### PR DESCRIPTION
## Description

Closes #615.

Add a global `autoBonding` setting (`'default'|'disable'|'force'|'nohetatm'`) that controls
whether bonds are automatically reconstructed on load, independent of file format:

- `'default'` keeps the existing per-format behavior (some formats reconstruct bonds, some don't).
- `'disable'` never reconstructs bonds, regardless of format.
- `'force'` always reconstructs bonds, regardless of format.
- `'nohetatm'` reconstructs bonds per the format's default behavior, but excludes HETATM atoms
  from auto-bonding (in either direction — as a seed atom and as a candidate neighbor). This only
  has an effect for formats with a genuine per-atom HETATM distinction read from the source file
  (PDB, CIF, MMTF); other formats hardcode the `het` flag to a single value for every atom and are
  intentionally left unaffected (wiring the exclusion into them would either silently drop all
  auto-generated bonds for GRO/XYZ, or be dead code for the rest).

A per-load override is available via `opts.autoBonding` on `Miew#load()`, taking precedence over
the global setting.

## Type of changes

- New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works.
- [x] I have added the necessary documentation.
