### PR TITLE
Add a description to the projected atom example

### DIFF
--- a/packages/miew/CHANGELOG.md
+++ b/packages/miew/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add a description to the "Project an atom onto the canvas" example, explaining why the
+  HTML marker stays visible while the canvas-drawn marker disappears when the tracked atom
+  moves outside the viewer's bounds.
+
 ### Fixed
 
 - Fix uncaught promise rejection when a load operation is cancelled. The `load()` promise now

--- a/packages/miew/examples/projected.html
+++ b/packages/miew/examples/projected.html
@@ -31,11 +31,25 @@
 </head>
 <body>
   <h1>Project an atom onto the canvas</h1>
-  <div style="position: absolute; border: 1px solid black">
+  <div style="position: relative; border: 1px solid black; width: 640px; height: 480px">
     <div class="miew-container" style="width:640px; height:480px"></div>
     <div id="marker" style="position:absolute"><div class="marker"></div></div>
     <canvas id="canvas" width="640" height ="480" class="canvas"></canvas>
   </div>
+
+  <p style="width: 640px">
+    This page demonstrates two ways of projecting an atom's 3D position onto the
+    2D canvas using <code>viewer.projected()</code>: a <span style="color: #d00000">red circle</span>,
+    which is a plain HTML element positioned with CSS, and a <span style="color: #008000">green circle</span>,
+    which is drawn directly onto an HTML5 canvas.
+  </p>
+  <p style="width: 640px">
+    Rotate the molecule so that the tracked atom (<code>A.1.CA</code>) moves out
+    of the viewer's bounds. The <span style="color: #d00000">red circle</span> stays visible because
+    the HTML element is not clipped by its container, while the <span style="color: #008000">green circle</span>
+    disappears because it is drawn on a canvas that clips its contents to its own width and height.
+    Both behaviors are expected.
+  </p>
 
   <script>
     (function() {


### PR DESCRIPTION
## Description

Closes #599.

The "Project an atom onto the canvas" example shows two markers tracking the same atom: a red circle (an absolutely positioned HTML element) and a green circle (drawn on an HTML5 canvas). When the tracked atom rotates out of the viewer's bounds, the red circle stays visible while the green one disappears, which can look like a bug.

This change adds two short paragraphs below the viewer explaining the two projection techniques and why the two markers behave differently when the atom leaves the viewport. The paragraphs are constrained to the container's 640px width, and the "red circle" / "green circle" references are colored to match (with darker shades kept legible on a white background).

## Type of changes

- New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] The changes do not require updated tests.
- [x] The changes do not require updated docs.
