### PR TITLE
Update supported Node.js versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,10 @@
 version: "{build}"
-image: Visual Studio 2022
+image: Visual Studio 2026
 environment:
   matrix:
+    - nodejs_version: "26"
     - nodejs_version: "24"
     - nodejs_version: "22"
-    - nodejs_version: "20"
 cache:
   - ".yarn\\cache"
   - node_modules

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ Note that the core library (`miew`) is framework-agnostic and does not depend on
 - **Webpack 5**: Module bundler for all packages
 - **Babel**: JavaScript transpilation with preset-env and preset-react
 - **Yarn 3**: Package manager with workspaces
-- **Node.js 20-24**: Development environment
+- **Node.js 22-26**: Development environment
 
 ### React Ecosystem (miew-app, miew-react)
 - **React 16/19**: UI framework

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [24, 22, 20]
+        node: [26, 24, 22]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node }}
         cache: 'yarn'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "engines": {
     "npm": ">=9.0.0 <12.0.0",
-    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+    "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },
   "scripts": {
     "clean": "rimraf coverage && yarn workspaces foreach -ptv run clean",


### PR DESCRIPTION
## Description

Fixes #683.

Node 20 reached end-of-life on 2026-03-24 and no longer receives security fixes, while Node 26 is now the current release. This updates the declared and tested Node.js versions across the repo (`engines.node`, GitHub Actions CI matrix, AppVeyor matrix, and `copilot-instructions.md`) so we stop giving a false sense of support for an unmaintained runtime and gain coverage for the incoming Node 26 LTS line.

Also bumps `actions/checkout` and `actions/setup-node` to v7, since older versions run on the Node 20 runtime that GitHub Actions is deprecating, which was causing deprecation warnings in CI logs unrelated to our own build matrix.

Verified GitHub Actions and AppVeyor builds succeed with these changes.

## Type of changes

- Dependency update (non-breaking change that updates third-party packages)

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/epam/miew/blob/master/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/epam/miew/blob/master/CODE_OF_CONDUCT.md) guides.
- [x] I have followed the code style of this project.
- [x] I have run `yarn run ci`: lint and tests pass locally with my changes.
- [x] I have added tests that prove my fix/feature works _OR_ The changes do not require updated tests.
- [x] I have added the necessary documentation _OR_ The changes do not require updated docs.
